### PR TITLE
Fix info hash generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redox"
-version = "0.0.0"
+version = "0.0.1"
 description = "A library implementing the bittorrent protocol and a few key extensions."
 
 authors = ["GGist <amiller4421@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redox"
-version = "0.1.0"
+version = "0.0.0"
 description = "A library implementing the bittorrent protocol and a few key extensions."
 
 authors = ["GGist <amiller4421@gmail.com>"]

--- a/src/torrent/metainfo/metainfo.rs
+++ b/src/torrent/metainfo/metainfo.rs
@@ -40,9 +40,10 @@ impl Metainfo {
         where B: AsRef<[u8]> {
         let mut bencode = try!(Bencode::decode(bytes));
     
-        let info = try!(PieceInfoImpl::new(&mut bencode));
+        // Should Be Calculated Before Anything Gets Moved Out
         let info_hash = try!(metainfo::generate_info_hash(&bencode));
-        
+    
+        let info = try!(PieceInfoImpl::new(&mut bencode));
         let file = try!(FileInfoImpl::new(&mut bencode));
         
         let announce = move_announce(&mut bencode);


### PR DESCRIPTION
Metainfo was incorrectly generating the info hash after moving the pieces list out of the Bencode object. This has been fixed and the info hash generator has been tested (still need to add some automated tests for this).
