### PR TITLE
Implement zero copy bencode parsing

### DIFF
--- a/examples/macro_test.rs
+++ b/examples/macro_test.rs
@@ -18,8 +18,8 @@ fn main() {
     };
     let udp = UdpSocket::bind("0.0.0.0:0").unwrap();
     
-    udp.send_to(&dht_msg.encode()[..], ("dht.transmissionbt.com", 6881)).unwrap();
-    let (len, addr) = udp.recv_from(&mut recv_buffer[..]).unwrap();
+    udp.send_to(&dht_msg.encode()[..], "212.129.33.50:6881").unwrap();
+    let (len, _) = udp.recv_from(&mut recv_buffer[..]).unwrap();
     
     let bencode = Bencode::decode(&recv_buffer[0..len]).unwrap();
     println!("{:?}", bencode);

--- a/src/bencode/encode.rs
+++ b/src/bencode/encode.rs
@@ -1,7 +1,7 @@
 use bencode::{self, BencodeView, BencodeKind};
 use util::{Dictionary};
 
-pub fn encode<T>(val: T) -> Vec<u8> where T: BencodeView {
+pub fn encode<'a, T>(val: T) -> Vec<u8> where T: BencodeView<'a> {
     match val.kind() {
         BencodeKind::Int(n)   => encode_int(n),
         BencodeKind::Bytes(n) => encode_bytes(&n),
@@ -30,7 +30,7 @@ fn encode_bytes(list: &[u8]) -> Vec<u8> {
     bytes
 }
     
-fn encode_list<T>(list: &[T]) -> Vec<u8> where T: BencodeView {
+fn encode_list<'a, T>(list: &[T]) -> Vec<u8> where T: BencodeView<'a> {
     let mut bytes: Vec<u8> = Vec::new();
     
     bytes.push(bencode::LIST_START);
@@ -42,8 +42,8 @@ fn encode_list<T>(list: &[T]) -> Vec<u8> where T: BencodeView {
     bytes
 }
     
-fn encode_dict<T>(dict: &Dictionary<String, T>) -> Vec<u8>
-    where T: BencodeView {
+fn encode_dict<'a, T>(dict: &Dictionary<'a, T>) -> Vec<u8>
+    where T: BencodeView<'a> {
     // Need To Sort The Keys In The Map Before Encoding
     let mut bytes: Vec<u8> = Vec::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Rust Bittorrent Library
 
-#![feature(collections)]
+#![feature(vec_push_all)]
 
 extern crate rand;
 extern crate sha1;

--- a/src/torrent/metainfo/lazy_metainfo.rs
+++ b/src/torrent/metainfo/lazy_metainfo.rs
@@ -51,7 +51,7 @@ macro_rules! slice_dict_opt {
 }
 
 /// Tries to convert the root BencodeView value to a Dictionary.
-pub fn slice_root_dict<'a, T>(root: &'a T) -> TorrentResult<&'a Dictionary<String, T>>
-    where T: BencodeView<InnerItem=T> {
+pub fn slice_root_dict<'a, T>(root: &T) -> TorrentResult<&Dictionary<'a, T>>
+    where T: BencodeView<'a, InnerView=T> + 'a {
     Ok(slice_ben!(root, metainfo::ROOT_IDENT, BencodeView::dict))
 }

--- a/src/torrent/metainfo/mod.rs
+++ b/src/torrent/metainfo/mod.rs
@@ -3,7 +3,6 @@
 use bencode::{BencodeView, EncodeBencode};
 use error::{TorrentResult, TorrentErrorKind, TorrentError};
 use info_hash::{self, InfoHash};
-use torrent::{self};
 use util::{self};
 
 mod metainfo;
@@ -40,8 +39,8 @@ const MD5SUM_LEN: usize = 32;
 const NODE_LEN:   usize = 2;
 
 /// Generate an InfoHash from the given BencodeView value.
-fn generate_info_hash<T>(root: &T) -> TorrentResult<InfoHash>
-    where T: BencodeView<InnerItem=T> {
+fn generate_info_hash<'a, T>(root: &T) -> TorrentResult<InfoHash>
+    where T: BencodeView<'a, InnerView=T> + 'a {
     let mut dest_bytes = [0u8; info_hash::INFO_HASH_LEN];
     let root_dict = try!(lazy_metainfo::slice_root_dict(root));
     

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,6 @@
 //! Utilities used throughout the library.
 
-use std::borrow::{Borrow};
-use std::collections::{HashMap, BTreeMap};
-use std::hash::{Hash};
+use std::collections::{BTreeMap};
 
 use rand;
 use sha1::{Sha1};
@@ -35,59 +33,37 @@ impl<'a, T: 'a + ?Sized> Iterator for Iter<'a, T> {
 }
 
 /// Trait for working with generic map data structures.
-pub trait Dictionary<K, V> where K: Borrow<str> {
+pub trait Dictionary<'a, V> {
     /// Convert the dictionary to an unordered list of key/value pairs.
-    fn to_list<'a>(&'a self) -> Vec<(&'a K, &'a V)>;
+    fn to_list(&self) -> Vec<(&&'a str, &V)>;
 
     /// Lookup a value in the dictionary.
-    fn lookup<'a>(&'a self, key: &str) -> Option<&'a V>;
+    fn lookup(&self, key: &str) -> Option<&V>;
     
     /// Lookup a mutable value in the dictionary.
-    fn lookup_mut<'a>(&'a mut self, key: &str) -> Option<&'a mut V>;
+    fn lookup_mut(&mut self, key: &str) -> Option<&mut V>;
 
     /// Insert a key/value pair into the dictionary.
-    fn insert(&mut self, key: K, value: V) -> Option<V>;
+    fn insert(&mut self, key: &'a str, value: V) -> Option<V>;
     
     /// Remove a value from the dictionary and return it.
     fn remove(&mut self, key: &str) -> Option<V>;
 }
 
-impl<K, V> Dictionary<K, V> for HashMap<K, V> where K: Hash + Eq + Borrow<str> {
-    fn to_list<'a>(&'a self) -> Vec<(&'a K, &'a V)> {
+impl<'a, V> Dictionary<'a, V> for BTreeMap<&'a str, V> {
+    fn to_list(&self) -> Vec<(&&'a str, &V)> {
         self.iter().collect()
     }
 
-    fn lookup<'a>(&'a self, key: &str) -> Option<&'a V> {
+    fn lookup(&self, key: &str) -> Option<&V> {
         self.get(key)
     }
     
-    fn lookup_mut<'a>(&'a mut self, key: &str) -> Option<&'a mut V> {
+    fn lookup_mut(&mut self, key: &str) -> Option<&mut V> {
         self.get_mut(key)
     }
 
-    fn insert(&mut self, key: K, value: V) -> Option<V> {
-        self.insert(key, value)
-    }
-    
-    fn remove(&mut self, key: &str) -> Option<V> {
-        self.remove(key)
-    }
-}
-
-impl<K, V> Dictionary<K, V> for BTreeMap<K, V> where K: Ord + Borrow<str> {
-    fn to_list<'a>(&'a self) -> Vec<(&'a K, &'a V)> {
-        self.iter().collect()
-    }
-
-    fn lookup<'a>(&'a self, key: &str) -> Option<&'a V> {
-        self.get(key)
-    }
-    
-    fn lookup_mut<'a>(&'a mut self, key: &str) -> Option<&'a mut V> {
-        self.get_mut(key)
-    }
-
-    fn insert(&mut self, key: K, value: V) -> Option<V> {
+    fn insert(&mut self, key: &'a str, value: V) -> Option<V> {
         self.insert(key, value)
     }
     


### PR DESCRIPTION
Implements zero copy parsing semantics for bencode parsing. Initial tests show a 32x speedup on a 44kb bencode file. This speedup should grow with the size of the file being parsed.
