### PR TITLE
Add UDP Tracker Messaging Primitives

### DIFF
--- a/bip_utracker/Cargo.toml
+++ b/bip_utracker/Cargo.toml
@@ -1,16 +1,23 @@
 [package]
-name        = "bip_utracker"
-version     = "0.0.2"
-description = "Communication with bittorrent UDP trackers"
+name          = "bip_utracker"
+version       = "0.0.2"
+description   = "Communication with bittorrent UDP trackers"
 
-authors     = ["Andrew <amiller4421@gmail.com>"]
+authors       = ["Andrew <amiller4421@gmail.com>"]
 
-homepage    = "https://github.com/GGist/bip-rs/bip_utracker"
-repository  = "https://github.com/GGist/bip-rs/bip_utracker"
+homepage      = "https://github.com/GGist/bip-rs/bip_utracker"
+repository    = "https://github.com/GGist/bip-rs/bip_utracker"
 
-keywords    = ["tracker", "bittorrent", "udp"]
+keywords      = ["tracker", "bittorrent", "udp"]
 
-license     = "MIT/Apache-2.0"
+license       = "MIT/Apache-2.0"
+
+[dependencies]
+bip_handshake = { path = "../bip_handshake", version = "0.1.0" }
+bip_util      = { path = "../bip_util", version = "0.3.0" }
+byteorder     = "0.5.0"
+nom           = "1.2.0"
+umio          = "0.1.0"
 
 [features]
-unstable = []
+unstable      = []

--- a/bip_utracker/src/announce.rs
+++ b/bip_utracker/src/announce.rs
@@ -1,0 +1,959 @@
+//! Announce constructs used to gather peers.
+
+use std::io::{self, Write};
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use bip_util::bt::{self, InfoHash, PeerId};
+use bip_util::convert::{self};
+use byteorder::{WriteBytesExt, BigEndian};
+use nom::{IResult, be_i32, be_i64, be_u32, be_u16, be_u8};
+
+use contact::{CompactPeers};
+use option::{AnnounceOptions};
+
+const IMPLIED_IPV4_ID: [u8; 4]  = [0u8; 4];
+const IMPLIED_IPV6_ID: [u8; 16] = [0u8; 16];
+
+const DEFAULT_NUM_WANT: i32 = -1;
+
+const ANNOUNCE_NONE_EVENT:      i32 = 0;
+const ANNOUNCE_COMPLETED_EVENT: i32 = 1;
+const ANNOUNCE_STARTED_EVENT:   i32 = 2;
+const ANNOUNCE_STOPPED_EVENT:   i32 = 3;
+
+/// Announce request sent from the client to the server.
+///
+/// IPv6 is supported but is [not standard](http://opentracker.blog.h3q.com/2007/12/28/the-ipv6-situation/).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AnnounceRequest<'a> {
+    info_hash: InfoHash,
+    peer_id:   PeerId,
+    state:     ClientState,
+    ip:        SourceIP,
+    key:       u32,
+    num_want:  DesiredPeers,
+    port:      u16,
+    options:   AnnounceOptions<'a>
+}
+
+impl<'a> AnnounceRequest<'a> {
+    /// Create a new AnnounceRequest.
+    pub fn new(hash: InfoHash, peer_id: PeerId, state: ClientState, ip: SourceIP, key: u32,
+        num_want: DesiredPeers, port: u16, options: AnnounceOptions<'a>) -> AnnounceRequest<'a> {
+        AnnounceRequest{ info_hash: hash, peer_id: peer_id, state: state, ip: ip, key: key,
+            num_want: num_want, port: port, options: options }
+    }
+
+    /// Construct an IPv4 AnnounceRequest from the given bytes.
+    pub fn from_bytes_v4(bytes: &'a [u8]) -> IResult<&'a [u8], AnnounceRequest<'a>> {
+        parse_request(bytes, SourceIP::from_bytes_v4)
+    }
+    
+    /// Construct an IPv6 AnnounceRequest from the given bytes.
+    pub fn from_bytes_v6(bytes: &'a [u8]) -> IResult<&'a [u8], AnnounceRequest<'a>> {
+        parse_request(bytes, SourceIP::from_bytes_v6)
+    }
+    
+    /// Write the AnnounceRequest to the given writer.
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        try!(writer.write_all(self.info_hash.as_ref()));
+        try!(writer.write_all(self.peer_id.as_ref()));
+        
+        try!(self.state.write_bytes(&mut writer));
+        try!(self.ip.write_bytes(&mut writer));
+        
+        try!(writer.write_u32::<BigEndian>(self.key));
+        
+        try!(self.num_want.write_bytes(&mut writer));
+        
+        try!(writer.write_u16::<BigEndian>(self.port));
+        
+        try!(self.options.write_bytes(&mut writer));
+        
+        Ok(())
+    }
+    
+    /// InfoHash of the current request.
+    pub fn info_hash(&self) -> InfoHash {
+        self.info_hash
+    }
+    
+    /// PeerId of the current request.
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+    
+    /// State reported by the client in the given request.
+    pub fn state(&self) -> ClientState {
+        self.state
+    }
+    
+    /// Source address to send the response to.
+    pub fn source_ip(&self) -> SourceIP {
+        self.ip
+    }
+    
+    /// Unique key randomized by the client that the server can use.
+    pub fn key(&self) -> u32 {
+        self.key
+    }
+    
+    /// Number of peers desired by the client.
+    pub fn num_want(&self) -> DesiredPeers {
+        self.num_want
+    }
+    
+    /// Port to send the response to.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+    
+    /// Set of AnnounceOptions supplied in the request.
+    pub fn options(&self) -> &AnnounceOptions<'a> {
+        &self.options
+    }
+}
+
+/// Parse an AnnounceRequest with the given SourceIP type constructor.
+fn parse_request<'a>(bytes: &'a [u8], ip_type: fn(bytes: &[u8]) -> IResult<&[u8], SourceIP>)
+    -> IResult<&'a [u8], AnnounceRequest<'a>> {
+    chain!(bytes,
+        info_hash:  map!(take!(bt::INFO_HASH_LEN), |bytes| InfoHash::from_hash(bytes).unwrap()) ~
+        peer_id:    map!(take!(bt::PEER_ID_LEN), |bytes| PeerId::from_hash(bytes).unwrap()) ~
+        state:   call!(ClientState::from_bytes) ~
+        ip:         call!(ip_type) ~
+        key:        be_u32 ~
+        num_want:   call!(DesiredPeers::from_bytes) ~
+        port:       be_u16 ~
+        options:    call!(AnnounceOptions::from_bytes) ,
+        || { AnnounceRequest::new(info_hash, peer_id, state, ip, key, num_want, port, options) }
+    )
+}
+
+//----------------------------------------------------------------------------//
+
+/// Announce response sent from the server to the client.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AnnounceResponse<'a> {
+    interval: i32,
+    leechers: i32,
+    seeders:  i32,
+    peers:    CompactPeers<'a>
+}
+
+impl<'a> AnnounceResponse<'a> {
+    /// Create a new AnnounceResponse
+    pub fn new(interval: i32, leechers: i32, seeders: i32, peers: CompactPeers<'a>) -> AnnounceResponse<'a> {
+        AnnounceResponse{ interval: interval, leechers: leechers, seeders: seeders, peers: peers }
+    }
+    
+    /// Construct an IPv4 AnnounceResponse from the given bytes.
+    pub fn from_bytes_v4(bytes: &'a [u8]) -> IResult<&'a [u8], AnnounceResponse<'a>> {
+        parse_respone(bytes, CompactPeers::from_bytes_v4)
+    }
+    
+    /// Construct an IPv6 AnnounceResponse from the given bytes.
+    pub fn from_bytes_v6(bytes: &'a [u8]) -> IResult<&'a [u8], AnnounceResponse<'a>> {
+        parse_respone(bytes, CompactPeers::from_bytes_v6)
+    }
+    
+    /// Write the AnnounceResponse to the given writer.
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        try!(writer.write_i32::<BigEndian>(self.interval));
+        try!(writer.write_i32::<BigEndian>(self.leechers));
+        try!(writer.write_i32::<BigEndian>(self.seeders));
+        
+        try!(self.peers.write_bytes(&mut writer));
+        
+        Ok(())
+    }
+    
+    /// Interval in seconds that clients should wait before re-announcing.
+    pub fn interval(&self) -> i32 {
+        self.interval
+    }
+    
+    /// Number of leechers the tracker knows about for the torrent.
+    pub fn leechers(&self) -> i32 {
+        self.leechers
+    }
+    
+    /// Number of seeders the tracker knows about for the torrent.
+    pub fn seeders(&self) -> i32 {
+        self.seeders
+    }
+    
+    /// Peers the tracker know about that are sharing the torrent.
+    pub fn peers(&self) -> &CompactPeers<'a> {
+        &self.peers
+    }
+}
+
+/// Parse an AnnounceResponse with the given CompactPeers type constructor.
+fn parse_respone<'a>(bytes: &'a [u8], peers_type: fn(bytes: &'a [u8]) -> IResult<&'a [u8], CompactPeers<'a>>)
+    -> IResult<&'a [u8], AnnounceResponse<'a>> {
+    chain!(bytes,
+        interval: be_i32 ~
+        leechers: be_i32 ~
+        seeders:  be_i32 ~
+        peers:    call!(peers_type) ,
+        || { AnnounceResponse::new(interval, leechers, seeders, peers) }
+    )
+}
+
+//----------------------------------------------------------------------------//
+
+/// Announce state of a client reported to the server.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct ClientState {
+    downloaded: i64,
+    left:       i64,
+    uploaded:   i64,
+    event:      AnnounceEvent
+}
+
+impl ClientState {
+    /// Create a new ClientState.
+    pub fn new(bytes_downloaded: i64, bytes_left: i64, bytes_uploaded: i64, event: AnnounceEvent) -> ClientState {
+        ClientState{ downloaded: bytes_downloaded, left: bytes_left, uploaded: bytes_uploaded, event: event }
+    }
+    
+    /// Construct the ClientState from the given bytes.
+    pub fn from_bytes(bytes: &[u8]) -> IResult<&[u8], ClientState> {
+        parse_state(bytes)
+    }
+    
+    /// Write the ClientState to the given writer.
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        try!(writer.write_i64::<BigEndian>(self.downloaded));
+        try!(writer.write_i64::<BigEndian>(self.left));
+        try!(writer.write_i64::<BigEndian>(self.uploaded));
+        
+        try!(self.event.write_bytes(&mut writer));
+        
+        Ok(())
+    }
+    
+    /// Event reported by the client.
+    pub fn event(&self) -> AnnounceEvent {
+        self.event
+    }
+    
+    /// Bytes left to be downloaded.
+    pub fn bytes_left(&self) -> i64 {
+        self.left
+    }
+    
+    /// Bytes already uploaded.
+    pub fn bytes_uploaded(&self) -> i64 {
+        self.uploaded
+    }
+    
+    /// Bytes already downloaded.
+    pub fn bytes_downloaded(&self) -> i64 {
+        self.downloaded
+    }
+}
+
+fn parse_state(bytes: &[u8]) -> IResult<&[u8], ClientState> {
+    chain!(bytes,
+        downloaded: be_i64 ~
+        left:       be_i64 ~
+        uploaded:   be_i64 ~
+        event:      call!(AnnounceEvent::from_bytes) ,
+        || { ClientState::new(downloaded, left, uploaded, event) }
+    )
+}
+
+//----------------------------------------------------------------------------//
+
+/// Announce event of a client reported to the server.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AnnounceEvent {
+    /// No event is reported.
+    None,
+    /// Torrent download has completed.
+    Completed,
+    /// Torrent download has started.
+    Started,
+    /// Torrent download has stopped.
+    Stopped
+}
+
+impl AnnounceEvent {
+    /// Construct an AnnounceEvent from the given bytes.
+    pub fn from_bytes(bytes: &[u8]) -> IResult<&[u8], AnnounceEvent> {
+        parse_event(bytes)
+    }
+    
+    /// Write the AnnounceEvent to the given writer.
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        try!(writer.write_i32::<BigEndian>(self.as_id()));
+        
+        Ok(())
+    }
+    
+    /// Access the raw id of the current event.
+    pub fn as_id(&self) -> i32 {
+        match self {
+            &AnnounceEvent::None      => ANNOUNCE_NONE_EVENT,
+            &AnnounceEvent::Completed => ANNOUNCE_COMPLETED_EVENT,
+            &AnnounceEvent::Started   => ANNOUNCE_STARTED_EVENT,
+            &AnnounceEvent::Stopped   => ANNOUNCE_STOPPED_EVENT
+        }
+    }
+}
+
+fn parse_event(bytes: &[u8]) -> IResult<&[u8], AnnounceEvent> {
+    switch!(bytes, be_i32,
+        ANNOUNCE_NONE_EVENT      => value!(AnnounceEvent::None)      |
+        ANNOUNCE_COMPLETED_EVENT => value!(AnnounceEvent::Completed) |
+        ANNOUNCE_STARTED_EVENT   => value!(AnnounceEvent::Started)   |
+        ANNOUNCE_STOPPED_EVENT   => value!(AnnounceEvent::Stopped)
+    )
+}
+
+//----------------------------------------------------------------------------//
+
+/// Client specified IP address to send the response to.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum SourceIP {
+    /// Infer the IPv4 address from the sender address.
+    ImpliedV4,
+    /// Send the response to the given IPv4 address.
+    ExplicitV4(Ipv4Addr),
+    /// Infer the IPv6 address from the sender address.
+    ImpliedV6,
+    /// Send the response to the given IPv6 address.
+    ExplicitV6(Ipv6Addr)
+}
+
+impl SourceIP {
+    /// Construct the IPv4 SourceIP from the given bytes.
+    pub fn from_bytes_v4(bytes: &[u8]) -> IResult<&[u8], SourceIP> {
+        parse_preference_v4(bytes)
+    }
+    
+    /// Construct the IPv6 SourceIP from the given bytes.
+    pub fn from_bytes_v6(bytes: &[u8]) -> IResult<&[u8], SourceIP> {
+        parse_preference_v6(bytes)
+    }
+    
+    /// Write the SourceIP to the given writer.
+    pub fn write_bytes<W>(&self, writer: W) -> io::Result<()>
+        where W: Write {
+        match self {
+            &SourceIP::ImpliedV4        => self.write_bytes_slice(writer, &IMPLIED_IPV4_ID[..]),
+            &SourceIP::ImpliedV6        => self.write_bytes_slice(writer, &IMPLIED_IPV6_ID[..]),
+            &SourceIP::ExplicitV4(addr) => self.write_bytes_slice(writer, &convert::ipv4_to_bytes_be(addr)[..]),
+            &SourceIP::ExplicitV6(addr) => self.write_bytes_slice(writer, &convert::ipv6_to_bytes_be(addr)[..]),
+        }
+    }
+    
+    /// Whether or not the source is an IPv6 address.
+    pub fn is_ipv6(&self) -> bool {
+        match self {
+            &SourceIP::ImpliedV6     => true,
+            &SourceIP::ExplicitV6(_) => true,
+            &SourceIP::ImpliedV4     => false,
+            &SourceIP::ExplicitV4(_) => false
+        }
+    }
+    
+    /// Whether or not the source is an IPv4 address.
+    pub fn is_ipv4(&self) -> bool {
+        !self.is_ipv6()
+    }
+    
+    /// Write the given byte slice to the given writer.
+    fn write_bytes_slice<W>(&self, mut writer: W, bytes: &[u8]) -> io::Result<()>
+        where W: Write {
+        writer.write_all(bytes)
+    }
+}
+
+fn parse_preference_v4(bytes: &[u8]) -> IResult<&[u8], SourceIP> {
+    alt!(bytes,
+        tag!(IMPLIED_IPV4_ID) => { |_| SourceIP::ImpliedV4 } |
+        parse_ipv4            => { |ipv4| SourceIP::ExplicitV4(ipv4) }
+    )
+}
+
+named!(parse_ipv4<&[u8], Ipv4Addr>,
+    map!(count_fixed!(u8, be_u8, 4), |b| convert::bytes_be_to_ipv4(b))
+);
+
+fn parse_preference_v6(bytes: &[u8]) -> IResult<&[u8], SourceIP> {
+    alt!(bytes,
+        tag!(IMPLIED_IPV6_ID) => { |_| SourceIP::ImpliedV6 } |
+        parse_ipv6            => { |ipv6| SourceIP::ExplicitV6(ipv6) }
+    )
+}
+
+named!(parse_ipv6<&[u8], Ipv6Addr>,
+    map!(count_fixed!(u8, be_u8, 16), |b| convert::bytes_be_to_ipv6(b))
+);
+
+//----------------------------------------------------------------------------//
+
+/// Client desired number of peers to send in the response.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum DesiredPeers {
+    /// Send the default number of peers.
+    Default,
+    /// Send a specific number of peers.
+    Specified(i32)
+}
+
+impl DesiredPeers {
+    /// Construct the DesiredPeers from the given bytes.
+    pub fn from_bytes(bytes: &[u8]) -> IResult<&[u8], DesiredPeers> {
+        parse_desired(bytes)
+    }
+    
+    /// Write the DesiredPeers to the given writer.
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        let write_value = match self {
+            &DesiredPeers::Default          => DEFAULT_NUM_WANT,
+            &DesiredPeers::Specified(count) => count
+        };
+        try!(writer.write_i32::<BigEndian>(write_value));
+        
+        Ok(())
+    }
+}
+
+fn parse_desired(bytes: &[u8]) -> IResult<&[u8], DesiredPeers> {
+    // Tuple trick used to subvert the unused pattern warning (nom tries to catch all)
+    switch!(bytes, tuple!(be_i32, value!(true)),
+        (DEFAULT_NUM_WANT, true) => value!(DesiredPeers::Default) |
+        (specified_peers, true)  => value!(DesiredPeers::Specified(specified_peers))
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr};
+    use std::io::{Write};
+
+    use bip_util::bt::{InfoHash, PeerId};
+    use bip_util::convert::{self};
+    use byteorder::{WriteBytesExt, BigEndian};
+    use nom::{IResult};
+    
+    use contact::{CompactPeers, CompactPeersV4, CompactPeersV6};
+    use option::{AnnounceOptions};
+    use super::{SourceIP, AnnounceEvent, ClientState, AnnounceRequest, DesiredPeers, AnnounceResponse};
+    
+    #[test]
+    fn positive_write_request() {
+        let mut received = Vec::new();
+        
+        let info_hash = [3, 4, 2, 3, 4, 3, 1, 6, 7, 56, 3, 234, 2, 3, 4, 3, 5, 6, 7, 8];
+        let peer_id = [4, 2, 123, 23, 34, 5, 56, 2, 3, 4, 45, 6, 7, 8, 5, 6, 4, 56, 34, 42];
+        let (downloaded, left, uploaded) = (123908, 12309123, 123123);
+        let state = ClientState::new(downloaded, left, uploaded, AnnounceEvent::None);
+        let ip = Ipv4Addr::new(127, 0, 0, 1);
+        let key = 234234;
+        let num_want = 34;
+        let port = 6969;
+        let options = AnnounceOptions::new();
+        let request = AnnounceRequest::new(info_hash.into(), peer_id.into(), state, SourceIP::ExplicitV4(ip),
+            key, DesiredPeers::Specified(num_want), port, options.clone());
+            
+        request.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_all(&info_hash).unwrap();
+        expected.write_all(&peer_id).unwrap();
+        expected.write_i64::<BigEndian>(downloaded).unwrap();
+        expected.write_i64::<BigEndian>(left).unwrap();
+        expected.write_i64::<BigEndian>(uploaded).unwrap();
+        expected.write_i32::<BigEndian>(super::ANNOUNCE_NONE_EVENT).unwrap();
+        expected.write_all(&convert::ipv4_to_bytes_be(ip)).unwrap();
+        expected.write_u32::<BigEndian>(key).unwrap();
+        expected.write_i32::<BigEndian>(num_want).unwrap();
+        expected.write_u16::<BigEndian>(port).unwrap();
+        options.write_bytes(&mut expected).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_response() {
+        let mut received = Vec::new();
+        
+        let (interval, leechers, seeders) = (213123, 3423423, 2342343);
+        let mut peers = CompactPeersV4::new();
+        peers.insert("127.0.0.1:2342".parse().unwrap());
+        peers.insert("127.0.0.2:0".parse().unwrap());
+        
+        let response = AnnounceResponse::new(interval, leechers, seeders, CompactPeers::V4(peers.clone()));
+        
+        response.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_i32::<BigEndian>(interval).unwrap();
+        expected.write_i32::<BigEndian>(leechers).unwrap();
+        expected.write_i32::<BigEndian>(seeders).unwrap();
+        peers.write_bytes(&mut expected).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_state() {
+        let mut received = Vec::new();
+        
+        let (downloaded, left, uploaded) = (123908, 12309123, 123123);
+        let state = ClientState::new(downloaded, left, uploaded, AnnounceEvent::None);
+        state.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_i64::<BigEndian>(downloaded).unwrap();
+        expected.write_i64::<BigEndian>(left).unwrap();
+        expected.write_i64::<BigEndian>(uploaded).unwrap();
+        expected.write_i32::<BigEndian>(super::ANNOUNCE_NONE_EVENT).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_none_event() {
+        let mut received = Vec::new();
+        
+        let none_event = AnnounceEvent::None;
+        none_event.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_i32::<BigEndian>(super::ANNOUNCE_NONE_EVENT).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_completed_event() {
+        let mut received = Vec::new();
+        
+        let none_event = AnnounceEvent::Completed;
+        none_event.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_i32::<BigEndian>(super::ANNOUNCE_COMPLETED_EVENT).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_started_event() {
+        let mut received = Vec::new();
+        
+        let none_event = AnnounceEvent::Started;
+        none_event.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_i32::<BigEndian>(super::ANNOUNCE_STARTED_EVENT).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_stopped_event() {
+        let mut received = Vec::new();
+        
+        let none_event = AnnounceEvent::Stopped;
+        none_event.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_i32::<BigEndian>(super::ANNOUNCE_STOPPED_EVENT).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_source_ipv4_implied() {
+        let mut received = Vec::new();
+        
+        let implied_ip = SourceIP::ImpliedV4;
+        implied_ip.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_all(&super::IMPLIED_IPV4_ID).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_source_ipv6_implied() {
+        let mut received = Vec::new();
+        
+        let implied_ip = SourceIP::ImpliedV6;
+        implied_ip.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_all(&super::IMPLIED_IPV6_ID).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    
+    #[test]
+    fn positive_write_source_ipv4_explicit() {
+        let mut received = Vec::new();
+        
+        let ip = Ipv4Addr::new(127, 0, 0, 1);
+        let explicit_ip = SourceIP::ExplicitV4(ip);
+        explicit_ip.write_bytes(&mut received).unwrap();
+        
+        let mut expected = convert::ipv4_to_bytes_be(ip);
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_source_ipv6_explicit() {
+        let mut received = Vec::new();
+        
+        let ip = "ADBB:234A:55BD:FF34:3D3A:FFFF:234A:55BD".parse().unwrap();
+        let explicit_ip = SourceIP::ExplicitV6(ip);
+        explicit_ip.write_bytes(&mut received).unwrap();
+        
+        let mut expected = convert::ipv6_to_bytes_be(ip);
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_desired_peers_default() {
+        let mut received = Vec::new();
+        
+        let desired_peers = DesiredPeers::Default;
+        desired_peers.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_i32::<BigEndian>(super::DEFAULT_NUM_WANT).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_desired_peers_specified() {
+        let mut received = Vec::new();
+        
+        let desired_peers = DesiredPeers::Specified(500);
+        desired_peers.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_i32::<BigEndian>(500).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_parse_request_empty_options() {
+        let info_hash = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1];
+        let peer_id   = [2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3];
+        
+        let (downloaded, left, uploaded) = (456789, 283465, 200000);
+        let state = ClientState::new(downloaded, left, uploaded, AnnounceEvent::Completed);
+        
+        let ip = SourceIP::ImpliedV4;
+        let (key, num_want, port) = (255123, -102340, 1515);
+        
+        let mut bytes = Vec::new();
+        bytes.write_all(&info_hash[..]).unwrap();
+        bytes.write_all(&peer_id[..]).unwrap();
+        bytes.write_i64::<BigEndian>(downloaded).unwrap();
+        bytes.write_i64::<BigEndian>(left).unwrap();
+        bytes.write_i64::<BigEndian>(uploaded).unwrap();
+        bytes.write_i32::<BigEndian>(super::ANNOUNCE_COMPLETED_EVENT).unwrap();
+        bytes.write_all(&super::IMPLIED_IPV4_ID).unwrap();
+        bytes.write_u32::<BigEndian>(key).unwrap();
+        bytes.write_i32::<BigEndian>(num_want).unwrap();
+        bytes.write_u16::<BigEndian>(port).unwrap();
+        
+        let received = match AnnounceRequest::from_bytes_v4(&bytes) {
+            IResult::Done(_, rec) => rec,
+            _                     => panic!("AnnounceRequest Parsing Failed...")
+        };
+        
+        assert_eq!(received.info_hash(), InfoHash::from(info_hash));
+        assert_eq!(received.peer_id(), PeerId::from(peer_id));
+        assert_eq!(received.state(), state);
+        assert_eq!(received.source_ip(), ip);
+        assert_eq!(received.key(), key);
+        assert_eq!(received.num_want(), DesiredPeers::Specified(num_want));
+        assert_eq!(received.port(), port);
+    }
+    
+    #[test]
+    fn negative_parse_request_missing_key() {
+        let info_hash = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1];
+        let peer_id   = [2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3, 2, 3];
+        
+        let (downloaded, left, uploaded) = (456789, 283465, 200000);
+        let state = ClientState::new(downloaded, left, uploaded, AnnounceEvent::Completed);
+        
+        let ip = SourceIP::ImpliedV4;
+        let (key, num_want, port) = (255123, -102340, 1515);
+        
+        let mut bytes = Vec::new();
+        bytes.write_all(&info_hash[..]).unwrap();
+        bytes.write_all(&peer_id[..]).unwrap();
+        bytes.write_i64::<BigEndian>(downloaded).unwrap();
+        bytes.write_i64::<BigEndian>(left).unwrap();
+        bytes.write_i64::<BigEndian>(uploaded).unwrap();
+        bytes.write_i32::<BigEndian>(super::ANNOUNCE_COMPLETED_EVENT).unwrap();
+        bytes.write_all(&super::IMPLIED_IPV4_ID).unwrap();
+        bytes.write_i32::<BigEndian>(num_want).unwrap();
+        bytes.write_u16::<BigEndian>(port).unwrap();
+        
+        let received = AnnounceRequest::from_bytes_v4(&bytes);
+        
+        assert!(received.is_incomplete());
+    }
+    
+    #[test]
+    fn positive_parse_response_empty_peers() {
+        let (interval, leechers, seeders) = (34, 234, 0);
+    
+        let mut bytes = Vec::new();
+        bytes.write_i32::<BigEndian>(interval).unwrap();
+        bytes.write_i32::<BigEndian>(leechers).unwrap();
+        bytes.write_i32::<BigEndian>(seeders).unwrap();
+        
+        let received_v4 = AnnounceResponse::from_bytes_v4(&bytes);
+        let received_v6 = AnnounceResponse::from_bytes_v6(&bytes);
+        
+        let expected_v4 = AnnounceResponse::new(interval, leechers, seeders,
+            CompactPeers::V4(CompactPeersV4::new()));
+        let expected_v6 = AnnounceResponse::new(interval, leechers, seeders,
+            CompactPeers::V6(CompactPeersV6::new()));
+    
+        assert_eq!(received_v4, IResult::Done(&b""[..], expected_v4));
+        assert_eq!(received_v6, IResult::Done(&b""[..], expected_v6));
+    }
+    
+    #[test]
+    fn positive_parse_response_many_peers() {
+        let (interval, leechers, seeders) = (34, 234, 0);
+    
+        let mut peers_v4 = CompactPeersV4::new();
+        peers_v4.insert("127.0.0.1:3412".parse().unwrap());
+        peers_v4.insert("10.0.0.1:2323".parse().unwrap());
+        
+        let mut peers_v6 = CompactPeersV6::new();
+        peers_v6.insert("[ADBB:234A:55BD:FF34:3D3A:FFFF:234A:55BD]:3432".parse().unwrap());
+        peers_v6.insert("[ADBB:234A::FF34:3D3A:FFFF:234A:55BD]:2222".parse().unwrap());
+     
+        let mut bytes = Vec::new();
+        bytes.write_i32::<BigEndian>(interval).unwrap();
+        bytes.write_i32::<BigEndian>(leechers).unwrap();
+        bytes.write_i32::<BigEndian>(seeders).unwrap();
+        
+        let mut bytes_v4 = bytes.clone();
+        peers_v4.write_bytes(&mut bytes_v4).unwrap();
+        
+        let mut bytes_v6 = bytes.clone();
+        peers_v6.write_bytes(&mut bytes_v6).unwrap();
+        
+        let received_v4 = AnnounceResponse::from_bytes_v4(&bytes_v4);
+        let received_v6 = AnnounceResponse::from_bytes_v6(&bytes_v6);
+        
+        let expected_v4 = AnnounceResponse::new(interval, leechers, seeders,
+            CompactPeers::V4(peers_v4));
+        let expected_v6 = AnnounceResponse::new(interval, leechers, seeders,
+            CompactPeers::V6(peers_v6));
+    
+        assert_eq!(received_v4, IResult::Done(&b""[..], expected_v4));
+        assert_eq!(received_v6, IResult::Done(&b""[..], expected_v6));
+    }
+    
+    #[test]
+    fn positive_parse_state() {
+        let (downloaded, left, uploaded) = (202340, 52340, 5043);
+        
+        let mut bytes = Vec::new();
+        bytes.write_i64::<BigEndian>(downloaded).unwrap();
+        bytes.write_i64::<BigEndian>(left).unwrap();
+        bytes.write_i64::<BigEndian>(uploaded).unwrap();
+        bytes.write_i32::<BigEndian>(super::ANNOUNCE_NONE_EVENT).unwrap();
+        
+        let received = ClientState::from_bytes(&bytes);
+        let expected = ClientState::new(downloaded, left, uploaded, AnnounceEvent::None);
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn negative_parse_incomplete_state() {
+        let (downloaded, left, uploaded) = (202340, 52340, 5043);
+        
+        let mut bytes = Vec::new();
+        bytes.write_i64::<BigEndian>(downloaded).unwrap();
+        bytes.write_i64::<BigEndian>(left).unwrap();
+        bytes.write_i64::<BigEndian>(uploaded).unwrap();
+        
+        let received = ClientState::from_bytes(&bytes);
+        
+        assert!(received.is_incomplete());
+    }
+    
+    #[test]
+    fn positive_parse_none_event() {
+        let mut bytes = Vec::new();
+        bytes.write_i32::<BigEndian>(super::ANNOUNCE_NONE_EVENT).unwrap();
+        
+        let received = AnnounceEvent::from_bytes(&bytes);
+        let expected = AnnounceEvent::None;
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_completed_event() {
+        let mut bytes = Vec::new();
+        bytes.write_i32::<BigEndian>(super::ANNOUNCE_COMPLETED_EVENT).unwrap();
+        
+        let received = AnnounceEvent::from_bytes(&bytes);
+        let expected = AnnounceEvent::Completed;
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_started_event() {
+        let mut bytes = Vec::new();
+        bytes.write_i32::<BigEndian>(super::ANNOUNCE_STARTED_EVENT).unwrap();
+        
+        let received = AnnounceEvent::from_bytes(&bytes);
+        let expected = AnnounceEvent::Started;
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn negative_parse_no_event() {
+        let bytes = [1, 2, 3, 4];
+        
+        let received = AnnounceEvent::from_bytes(&bytes);
+        
+        assert!(received.is_err());
+    }
+    
+    #[test]
+    fn positive_parse_stopped_event() {
+        let mut bytes = Vec::new();
+        bytes.write_i32::<BigEndian>(super::ANNOUNCE_STOPPED_EVENT).unwrap();
+        
+        let received = AnnounceEvent::from_bytes(&bytes);
+        let expected = AnnounceEvent::Stopped;
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_implied_v4_source() {
+        let mut bytes = Vec::new();
+        bytes.write_all(&super::IMPLIED_IPV4_ID).unwrap();
+        
+        let received = SourceIP::from_bytes_v4(&bytes);
+        let expected = SourceIP::ImpliedV4;
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_explicit_v4_source() {
+        let bytes = [127, 0, 0, 1];
+        
+        let received = SourceIP::from_bytes_v4(&bytes);
+        let expected = SourceIP::ExplicitV4(Ipv4Addr::new(127, 0, 0, 1));
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_implied_v6_source() {
+        let mut bytes = Vec::new();
+        bytes.write_all(&super::IMPLIED_IPV6_ID).unwrap();
+        
+        let received = SourceIP::from_bytes_v6(&bytes);
+        let expected = SourceIP::ImpliedV6;
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_explicit_v6_source() {
+        let ip = "ADBB:234A:55BD:FF34:3D3A:FFFF:234A:55BD".parse().unwrap();
+        let bytes = convert::ipv6_to_bytes_be(ip);
+        
+        let received = SourceIP::from_bytes_v6(&bytes);
+        let expected = SourceIP::ExplicitV6(ip);
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    
+    #[test]
+    fn negative_parse_incomplete_v4_source() {
+        let bytes = [0, 0];
+        
+        let received = SourceIP::from_bytes_v4(&bytes);
+        
+        assert!(received.is_incomplete());
+    }
+    
+    #[test]
+    fn negative_parse_incomplete_v6_source() {
+        let bytes = [0, 0, 0, 0];
+        
+        let received = SourceIP::from_bytes_v6(&bytes);
+        
+        assert!(received.is_incomplete());
+    }
+    
+    #[test]
+    fn negative_parse_empty_v4_source() {
+        let bytes = [];
+        
+        let received = SourceIP::from_bytes_v4(&bytes);
+        
+        assert!(received.is_incomplete());
+    }
+    
+    #[test]
+    fn negative_parse_empty_v6_source() {
+        let bytes = [];
+        
+        let received = SourceIP::from_bytes_v6(&bytes);
+        
+        assert!(received.is_incomplete());
+    }
+    
+    #[test]
+    fn positive_parse_desired_peers_default() {
+        let default_bytes = convert::four_bytes_to_array(-1i32 as u32);
+        
+        let received = DesiredPeers::from_bytes(&default_bytes);
+        let expected = DesiredPeers::Default;
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_desired_peers_specified() {
+        let specified_bytes = convert::four_bytes_to_array(50);
+        
+        let received = DesiredPeers::from_bytes(&specified_bytes);
+        let expected = DesiredPeers::Specified(50);
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+}

--- a/bip_utracker/src/contact.rs
+++ b/bip_utracker/src/contact.rs
@@ -1,0 +1,420 @@
+use std::borrow::{Cow};
+use std::io::{self, Write};
+use std::net::{SocketAddrV4, SocketAddrV6};
+
+use bip_util::convert::{self};
+use nom::{IResult, Needed};
+
+const SOCKET_ADDR_V4_BYTES: usize = 6;
+const SOCKET_ADDR_V6_BYTES: usize = 18;
+
+/// Container for peers to be sent/received from a tracker.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CompactPeers<'a> {
+    V4(CompactPeersV4<'a>),
+    V6(CompactPeersV6<'a>)
+}
+
+impl<'a> CompactPeers<'a> {
+    /// Construct a CompactPeers::V4 from the given bytes.
+    pub fn from_bytes_v4(bytes: &'a [u8]) -> IResult<&'a [u8], CompactPeers<'a>> {
+        match CompactPeersV4::from_bytes(bytes) {
+            IResult::Done(i, peers)  => IResult::Done(i, CompactPeers::V4(peers)),
+            IResult::Error(err)      => IResult::Error(err),
+            IResult::Incomplete(need) => IResult::Incomplete(need)
+        }
+    }
+    
+    /// Construct a CompactPeers::V6 from the given bytes.
+    pub fn from_bytes_v6(bytes: &'a [u8]) -> IResult<&'a [u8], CompactPeers<'a>> {
+        match CompactPeersV6::from_bytes(bytes) {
+            IResult::Done(i, peers)   => IResult::Done(i, CompactPeers::V6(peers)),
+            IResult::Error(err)       => IResult::Error(err),
+            IResult::Incomplete(need) => IResult::Incomplete(need)
+        }
+    }
+    
+    /// Write the underlying CompactPeers to the given writer.
+    pub fn write_bytes<W>(&self, writer: W) -> io::Result<()>
+        where W: Write {
+        match self {
+            &CompactPeers::V4(ref peers) => peers.write_bytes(writer),
+            &CompactPeers::V6(ref peers) => peers.write_bytes(writer)
+        }
+    }
+}
+
+/// Container for IPv4 peers to be sent/received from a tracker.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompactPeersV4<'a> {
+    peers: Cow<'a, [u8]>
+}
+
+impl<'a> CompactPeersV4<'a> {
+    /// Create a new CompactPeersV4.
+    pub fn new() -> CompactPeersV4<'a> {
+        CompactPeersV4{ peers: Cow::Owned(Vec::new()) }
+    }
+    
+    /// Construct a CompactPeersV4 from the given bytes.
+    pub fn from_bytes(bytes: &'a [u8]) -> IResult<&'a [u8], CompactPeersV4<'a>> {
+        parse_peers_v4(bytes)
+    }
+    
+    /// Write the CompactPeersV4 to the given writer.
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        try!(writer.write_all(&*self.peers));
+        
+        Ok(())
+    }
+    
+    /// Add the given peer to the list of peers.
+    pub fn insert(&mut self, peer: SocketAddrV4) {
+        let peer_bytes = convert::sock_v4_to_bytes_be(peer);
+        
+        self.peers.to_mut().extend_from_slice(&peer_bytes);
+    }
+    
+    /// Iterator over all of the contact information.
+    pub fn iter<'b>(&'b self) -> CompactPeersV4Iter<'b> {
+        CompactPeersV4Iter::new(&*self.peers)
+    }
+}
+
+fn parse_peers_v4<'a>(bytes: &'a [u8]) -> IResult<&'a [u8], CompactPeersV4<'a>> {
+    let remainder_bytes = bytes.len() % SOCKET_ADDR_V4_BYTES;
+
+    if remainder_bytes != 0 {
+        IResult::Incomplete(Needed::Size(SOCKET_ADDR_V4_BYTES - remainder_bytes))
+    } else {
+        let end_of_bytes = &bytes[bytes.len()..bytes.len()];
+    
+        IResult::Done(end_of_bytes, CompactPeersV4{ peers: Cow::Borrowed(bytes) })
+    }
+}
+
+//----------------------------------------------------------------------------//
+
+/// Iterator over the SocketAddrV4 info for some peers.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct CompactPeersV4Iter<'a> {
+    peers:  &'a [u8],
+    offset: usize
+}
+
+impl<'a> CompactPeersV4Iter<'a> {
+    /// Create a new CompactPeersV4Iter.
+    fn new(peers: &'a [u8]) -> CompactPeersV4Iter<'a> {
+        CompactPeersV4Iter{ peers: peers, offset: 0 }
+    }
+}
+
+impl<'a> Iterator for CompactPeersV4Iter<'a> {
+    type Item = SocketAddrV4;
+    
+    fn next(&mut self) -> Option<SocketAddrV4> {
+        if self.offset == self.peers.len() {
+            None
+        } else {
+            let mut sock_bytes = [0u8; SOCKET_ADDR_V4_BYTES];
+            
+            for (src, dst) in self.peers.iter()
+                .skip(self.offset)
+                .take(SOCKET_ADDR_V4_BYTES)
+                .zip(sock_bytes.iter_mut()) {
+                *dst = *src;
+            }
+            self.offset += SOCKET_ADDR_V4_BYTES;
+            
+            Some(convert::bytes_be_to_sock_v4(sock_bytes))
+        }
+    }
+}
+
+//----------------------------------------------------------------------------//
+
+/// Container for IPv6 peers to be sent/received from a tracker.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompactPeersV6<'a> {
+    peers: Cow<'a, [u8]>
+}
+
+impl<'a> CompactPeersV6<'a> {
+    /// Create a new CompactPeersV6.
+    pub fn new() -> CompactPeersV6<'a> {
+        CompactPeersV6{ peers: Cow::Owned(Vec::new()) }
+    }
+    
+    /// Construct a CompactPeersV6 from the given bytes.
+    pub fn from_bytes(bytes: &'a [u8]) -> IResult<&'a [u8], CompactPeersV6<'a>> {
+        parse_peers_v6(bytes)
+    }
+    
+    /// Write the CompactPeersV6 to the given writer.
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        try!(writer.write_all(&*self.peers));
+        
+        Ok(())
+    }
+    
+    /// Add the given peer to the list of peers.
+    pub fn insert(&mut self, peer: SocketAddrV6) {
+        let peer_bytes = convert::sock_v6_to_bytes_be(peer);
+        
+        self.peers.to_mut().extend_from_slice(&peer_bytes);
+    }
+    
+    /// Iterator over all of the contact information.
+    pub fn iter<'b>(&'b self) -> CompactPeersV6Iter<'b> {
+        CompactPeersV6Iter::new(&*self.peers)
+    }
+}
+
+fn parse_peers_v6<'a>(bytes: &'a [u8]) -> IResult<&'a [u8], CompactPeersV6<'a>> {
+    let remainder_bytes = bytes.len() % SOCKET_ADDR_V6_BYTES;
+
+    if remainder_bytes != 0 {
+        IResult::Incomplete(Needed::Size(SOCKET_ADDR_V6_BYTES - remainder_bytes))
+    } else {
+        let end_of_bytes = &bytes[bytes.len()..bytes.len()];
+    
+        IResult::Done(end_of_bytes, CompactPeersV6{ peers: Cow::Borrowed(bytes) })
+    }
+}
+
+//----------------------------------------------------------------------------//
+
+/// Iterator over the SocketAddrV6 info for some peers.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct CompactPeersV6Iter<'a> {
+    peers:  &'a [u8],
+    offset: usize
+}
+
+impl<'a> CompactPeersV6Iter<'a> {
+    /// Create a new CompactPeersV6Iter.
+    fn new(peers: &'a [u8]) -> CompactPeersV6Iter<'a> {
+        CompactPeersV6Iter{ peers: peers, offset: 0 }
+    }
+}
+
+impl<'a> Iterator for CompactPeersV6Iter<'a> {
+    type Item = SocketAddrV6;
+    
+    fn next(&mut self) -> Option<SocketAddrV6> {
+        if self.offset == self.peers.len() {
+            None
+        } else {
+            let mut sock_bytes = [0u8; SOCKET_ADDR_V6_BYTES];
+            
+            for (src, dst) in self.peers.iter()
+                .skip(self.offset)
+                .take(SOCKET_ADDR_V6_BYTES)
+                .zip(sock_bytes.iter_mut()) {
+                *dst = *src;
+            }
+            self.offset += SOCKET_ADDR_V6_BYTES;
+            
+            Some(convert::bytes_be_to_sock_v6(sock_bytes))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nom::{IResult};
+
+    use super::{CompactPeersV4, CompactPeersV6, CompactPeersV4Iter, CompactPeersV6Iter};
+
+    #[test]
+    fn positive_iterate_v4() {
+        let mut peers = CompactPeersV4::new();
+        
+        let peer_one = "127.0.0.1:2354".parse().unwrap();
+        let peer_two = "10.0.0.5:3245".parse().unwrap();
+        
+        peers.insert(peer_one);
+        peers.insert(peer_two);
+        
+        let mut peers_iter = peers.iter();
+        
+        assert_eq!(peers_iter.next(), Some(peer_one));
+        assert_eq!(peers_iter.next(), Some(peer_two));
+        assert_eq!(peers_iter.next(), None);
+    }
+
+    #[test]
+    fn positive_parse_empty_v4() {
+        let bytes = [];
+        
+        let received = CompactPeersV4::from_bytes(&bytes);
+        let expected = CompactPeersV4::new();
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+
+    #[test]
+    fn positive_parse_peer_v4() {
+        let bytes = [127, 0, 0, 1, 0, 15];
+        
+        let received = CompactPeersV4::from_bytes(&bytes);
+        let mut expected = CompactPeersV4::new();
+        
+        expected.insert("127.0.0.1:15".parse().unwrap());
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_peers_v4() {
+        let bytes = [127, 0, 0, 1, 0, 15, 127, 0, 0, 1, 1, 0];
+        
+        let received = CompactPeersV4::from_bytes(&bytes);
+        let mut expected = CompactPeersV4::new();
+        
+        expected.insert("127.0.0.1:15".parse().unwrap());
+        expected.insert("127.0.0.1:256".parse().unwrap());
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_write_empty_v4() {
+        let mut received = Vec::new();
+        
+        let peers = CompactPeersV4::new();
+        peers.write_bytes(&mut received).unwrap();
+        
+        let expected = [];
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_peer_v4() {
+        let mut received = Vec::new();
+        
+        let mut peers = CompactPeersV4::new();
+        peers.insert("127.0.0.1:256".parse().unwrap());
+        peers.write_bytes(&mut received).unwrap();
+        
+        let expected = [127, 0, 0, 1, 1, 0];
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_peers_v4() {
+        let mut received = Vec::new();
+        
+        let mut peers = CompactPeersV4::new();
+        peers.insert("127.0.0.1:256".parse().unwrap());
+        peers.insert("127.0.0.1:0".parse().unwrap());
+        peers.write_bytes(&mut received).unwrap();
+        
+        let expected = [127, 0, 0, 1, 1, 0, 127, 0, 0, 1, 0, 0];
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_iterate_v6() {
+        let mut peers = CompactPeersV6::new();
+        
+        let peer_one = "[ADBB:234A:55BD:FF34:3D3A:FFFF:234A:55BD]:256".parse().unwrap();
+        let peer_two = "[ADBB:0000:55BD:FF34:3D3A::234A:55BD]:3923".parse().unwrap();
+        
+        peers.insert(peer_one);
+        peers.insert(peer_two);
+        
+        let mut peers_iter = peers.iter();
+        
+        assert_eq!(peers_iter.next(), Some(peer_one));
+        assert_eq!(peers_iter.next(), Some(peer_two));
+        assert_eq!(peers_iter.next(), None);
+    }
+    
+    #[test]
+    fn positive_parse_empty_v6() {
+        let bytes = [];
+        
+        let received = CompactPeersV6::from_bytes(&bytes);
+        let expected = CompactPeersV6::new();
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+
+    #[test]
+    fn positive_parse_peer_v6() {
+        let bytes = [0xAD, 0xBB, 0x23, 0x4A, 0x55, 0xBD, 0xFF, 0x34,
+            0x3D, 0x3A, 0x00, 0x00, 0x23, 0x4A, 0x55, 0xBD, 1, 0];
+        
+        let received = CompactPeersV6::from_bytes(&bytes);
+        let mut expected = CompactPeersV6::new();
+        
+        expected.insert("[ADBB:234A:55BD:FF34:3D3A::234A:55BD]:256".parse().unwrap());
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_peers_v6() {
+        let bytes = [0xAD, 0xBB, 0x23, 0x4A, 0x55, 0xBD, 0xFF, 0x34,
+            0x3D, 0x3A, 0x00, 0x00, 0x23, 0x4A, 0x55, 0xBD, 1, 0,
+            0xDA, 0xBB, 0x23, 0x4A, 0x55, 0xBD, 0xFF, 0x34,
+            0x3D, 0x3A, 0x00, 0x00, 0x23, 0x4A, 0x55, 0xBD, 2, 0];
+        
+        let received = CompactPeersV6::from_bytes(&bytes);
+        let mut expected = CompactPeersV6::new();
+        
+        expected.insert("[ADBB:234A:55BD:FF34:3D3A::234A:55BD]:256".parse().unwrap());
+        expected.insert("[DABB:234A:55BD:FF34:3D3A::234A:55BD]:512".parse().unwrap());
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_write_empty_v6() {
+        let mut received = Vec::new();
+        
+        let peers = CompactPeersV6::new();
+        peers.write_bytes(&mut received).unwrap();
+        
+        let expected = [];
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_peer_v6() {
+        let mut received = Vec::new();
+        
+        let mut peers = CompactPeersV6::new();
+        peers.insert("[ADBB:234A:55BD:FF34:3D3A::234A:55BD]:256".parse().unwrap());
+        peers.write_bytes(&mut received).unwrap();
+        
+        let expected = [0xAD, 0xBB, 0x23, 0x4A, 0x55, 0xBD, 0xFF, 0x34,
+            0x3D, 0x3A, 0x00, 0x00, 0x23, 0x4A, 0x55, 0xBD, 1, 0];
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_peers_v6() {
+        let mut received = Vec::new();
+        
+        let mut peers = CompactPeersV6::new();
+        peers.insert("[ADBB:234A:55BD:FF34:3D3A::234A:55BD]:256".parse().unwrap());
+        peers.insert("[DABB:234A:55BD:FF34:3D3A::234A:55BD]:512".parse().unwrap());
+        peers.write_bytes(&mut received).unwrap();
+        
+        let expected = [0xAD, 0xBB, 0x23, 0x4A, 0x55, 0xBD, 0xFF, 0x34,
+            0x3D, 0x3A, 0x00, 0x00, 0x23, 0x4A, 0x55, 0xBD, 1, 0,
+            0xDA, 0xBB, 0x23, 0x4A, 0x55, 0xBD, 0xFF, 0x34,
+            0x3D, 0x3A, 0x00, 0x00, 0x23, 0x4A, 0x55, 0xBD, 2, 0];
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+}

--- a/bip_utracker/src/error.rs
+++ b/bip_utracker/src/error.rs
@@ -1,0 +1,34 @@
+use std::io::{self, Write};
+
+use nom::{IResult};
+
+///Error reported by the server and sent to the client.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ErrorResponse<'a> {
+    message: &'a str
+}
+
+impl<'a> ErrorResponse<'a> {
+    /// Create a new ErrorResponse.
+    pub fn new(message: &'a str) -> ErrorResponse<'a> {
+        ErrorResponse{ message: message }
+    }
+    
+    /// Construct an ErrorResponse from the given bytes.
+    pub fn from_bytes(bytes: &'a [u8]) -> IResult<&'a [u8], ErrorResponse<'a>> {
+        map!(bytes, take_str!(bytes.len()), |m| ErrorResponse::new(m))
+    }
+    
+    /// Write the ErrorResponse to the given writer.
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        try!(writer.write_all(self.message.as_bytes()));
+        
+        Ok(())
+    }
+    
+    /// Message describing the error that occured.
+    pub fn message(&self) -> &str {
+        self.message
+    }
+}

--- a/bip_utracker/src/lib.rs
+++ b/bip_utracker/src/lib.rs
@@ -1,3 +1,24 @@
-#[test]
-fn it_works() {
-}
+extern crate bip_handshake;
+extern crate bip_util;
+extern crate umio;
+#[macro_use]
+extern crate nom;
+extern crate byteorder;
+
+// Action ids used in both requests and responses.
+const CONNECT_ACTION_ID:       u32 = 0;
+const ANNOUNCE_IPV4_ACTION_ID: u32 = 1;
+const SCRAPE_ACTION_ID:        u32 = 2;
+const ANNOUNCE_IPV6_ACTION_ID: u32 = 4;
+
+pub mod transaction;
+
+pub mod announce;
+pub mod contact;
+pub mod error;
+pub mod option;
+pub mod request;
+pub mod response;
+pub mod scrape;
+
+pub use bip_handshake::{Handshaker};

--- a/bip_utracker/src/option.rs
+++ b/bip_utracker/src/option.rs
@@ -1,0 +1,426 @@
+//! Supply optional information with an AnnounceRequest.
+
+use std::borrow::{Cow};
+use std::collections::{HashMap};
+use std::collections::hash_map::{Entry};
+use std::io::{self, Write};
+
+use byteorder::{WriteBytesExt};
+use nom::{IResult, be_u8, eof};
+
+const END_OF_OPTIONS_BYTE: u8 = 0x00;
+const NO_OPERATION_BYTE:   u8 = 0x01;
+const URL_DATA_BYTE:       u8 = 0x02;
+
+/// Trait for supplying optional information in an AnnounceRequest.
+pub trait AnnounceOption<'a>: Sized {
+    /// Byte specifying what option this is.
+    fn option_byte() -> u8;
+    
+    /// Length of the associated option data.
+    fn option_length(&self) -> usize;
+    
+    /// Reads the option content from the given bytes.
+    fn read_option(bytes: &'a [u8]) -> Option<Self>;
+
+    /// Writes the option payload into the given buffer.
+    fn write_option(&self, buffer: &mut [u8]);
+}
+
+//----------------------------------------------------------------------------//
+
+/// Set of announce options used to provide trackers with extra information.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct AnnounceOptions<'a> {
+    raw_options: HashMap<u8, Cow<'a, [u8]>>
+}
+
+impl<'a> AnnounceOptions<'a> {
+    /// Create a new set of AnnounceOptions.
+    pub fn new() -> AnnounceOptions<'a> {
+        AnnounceOptions{ raw_options: HashMap::new() }
+    }
+    
+    /// Parse a set of AnnounceOptions from the given bytes.
+    pub fn from_bytes(bytes: &'a [u8]) -> IResult<&'a [u8], AnnounceOptions<'a>> {
+        let mut raw_options = HashMap::new();
+        
+        map!(bytes, call!(parse_options, &mut raw_options), |_| {
+            AnnounceOptions{ raw_options: raw_options }
+        })
+    }
+    
+    /// Write the AnnounceOptions to the given writer.
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        for (byte, content) in self.raw_options.iter() {
+            for content_chunk in content.chunks(u8::max_value() as usize) {
+                let content_chunk_len = content_chunk.len() as u8;
+                
+                try!(writer.write_u8(*byte));
+                try!(writer.write_u8(content_chunk_len));
+                try!(writer.write_all(content_chunk));
+            }
+        }
+        
+        // If we can fit it in, include the option terminating byte, otherwise as per the
+        // spec, we can leave it out since we are assuming this is the end of the packet.
+        // TODO: Allow unused when the compile flag is stabilized
+        writer.write_u8(END_OF_OPTIONS_BYTE);
+        
+        Ok(())
+    }
+    
+    /// Search for and construct the given AnnounceOption from the current AnnounceOptions.
+    ///
+    /// Returns None if the option is not found or it failed to read from the given bytes.
+    pub fn get_option<O>(&'a self) -> Option<O>
+        where O: AnnounceOption<'a> {
+        self.raw_options.get(&O::option_byte()).and_then(|bytes|
+            O::read_option(&*bytes)
+        )
+    }
+    
+    /// Add an AnnounceOption to the current set of AnnounceOptions.
+    ///
+    /// Any existing option with a matching option byte will be replaced.
+    pub fn add_option<O>(&mut self, option: &O)
+        where O: AnnounceOption<'a> {
+        let mut bytes = vec![0u8; option.option_length()];
+        option.write_option(&mut bytes[..]);
+        
+        // Unfortunately we cannot return the replaced value unless we modified the
+        // AnnounceOption::read_option method to accept a Cow and give it that because
+        // we cant guarantee that the buffer is not Cow::Owned at the moment and would be
+        // dropped (replaced) after being constructed.
+        self.raw_options.insert(O::option_byte(), Cow::Owned(bytes));
+    }
+}
+
+/// Parse the options in the byte slice and store them in the option map.
+fn parse_options<'a>(bytes: &'a [u8], option_map: &mut HashMap<u8, Cow<'a, [u8]>>) -> IResult<&'a [u8], ()> {
+    alt!(bytes, parse_end_option | call!(parse_no_option, option_map) | call!(parse_user_option, option_map))
+}
+
+/// Parse an end of buffer or the end of option byte.
+named!(parse_end_option<&[u8], ()>, map!(alt!(
+    eof | tag!([END_OF_OPTIONS_BYTE])
+), |_| ()));
+
+/// Parse a noop byte followed by a recursive call to parse another option.
+fn parse_no_option<'a>(bytes: &'a [u8], option_map: &mut HashMap<u8, Cow<'a, [u8]>>) -> IResult<&'a [u8], ()> {
+    preceded!(bytes, tag!([NO_OPERATION_BYTE]), call!(parse_options, option_map))
+}
+
+/// Parse a user defined option followed by a recursive call to parse another option.
+fn parse_user_option<'a>(bytes: &'a [u8], option_map: &mut HashMap<u8, Cow<'a, [u8]>>) -> IResult<&'a [u8], ()> {
+    preceded!(bytes, chain!(
+        option_byte:     be_u8 ~
+        option_contents: length_bytes!(byte_usize) ,
+        || {
+            match option_map.entry(option_byte) {
+                Entry::Occupied(mut occ) => { occ.get_mut().to_mut().extend_from_slice(option_contents); },
+                Entry::Vacant(vac)       => { vac.insert(Cow::Borrowed(option_contents)); } 
+            };
+        }),
+        call!(parse_options, option_map)
+    )
+}
+
+/// Parse a single byte as an unsigned pointer size.
+named!(byte_usize<&[u8], usize>, map!(
+    be_u8, |b| b as usize
+));
+
+//----------------------------------------------------------------------------//
+
+/// Concatenated PATH and QUERY of a UDP tracker URL.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct URLDataOption<'a> {
+    url_data: &'a [u8]
+}
+
+impl<'a> URLDataOption<'a> {
+    /// Create a new URLDataOption from the given bytes.
+    pub fn new(url_data: &'a [u8]) -> URLDataOption<'a> {
+        URLDataOption{ url_data: url_data }
+    }
+}
+
+impl<'a> AnnounceOption<'a> for URLDataOption<'a> {
+    fn option_byte() -> u8 {
+        URL_DATA_BYTE
+    }
+    
+    fn option_length(&self) -> usize {
+        self.url_data.len()
+    }
+    
+    fn read_option(bytes: &'a [u8]) -> Option<URLDataOption<'a>> {
+        Some(URLDataOption{ url_data: bytes })
+    }
+
+    fn write_option(&self, mut buffer: &mut [u8]) {
+        buffer.write_all(&self.url_data).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Write};
+    use std::u8::{self};
+
+    use nom::{IResult};
+    
+    use super::{AnnounceOptions, URLDataOption};
+    
+    #[test]
+    fn positive_write_eof_option() {
+        let mut received = [];
+        
+        let options = AnnounceOptions::new();
+        options.write_bytes(&mut received[..]).unwrap();
+        
+        let expected = [];
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_empty_option() {
+        let mut received = Vec::new();
+        
+        let options = AnnounceOptions::new();
+        options.write_bytes(&mut received).unwrap();
+        
+        let expected = [super::END_OF_OPTIONS_BYTE];
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_single_option() {
+        let mut received = Vec::new();
+        
+        let option = URLDataOption::new(b"AA");
+        
+        let mut options = AnnounceOptions::new();
+        options.add_option(&option);
+        options.write_bytes(&mut received).unwrap();
+        
+        let expected = [super::URL_DATA_BYTE, 2, 'A' as u8, 'A' as u8, super::END_OF_OPTIONS_BYTE];
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_chunked_option() {
+        let mut received = Vec::new();
+        
+        let mut option_content = [0u8; 256];
+        option_content[255] = 123;
+        
+        let option = URLDataOption::new(&option_content);
+        let mut options = AnnounceOptions::new();
+        options.add_option(&option);
+        options.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_all(&[super::URL_DATA_BYTE, 255]).unwrap();
+        expected.write_all(option_content.chunks(255).nth(0).unwrap()).unwrap();
+        expected.write_all(&[super::URL_DATA_BYTE, 1]).unwrap();
+        expected.write_all(option_content.chunks(255).nth(1).unwrap()).unwrap();
+        expected.write_all(&[super::END_OF_OPTIONS_BYTE]).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_parse_empty_option() {
+        let bytes = [];
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+        let expected = AnnounceOptions::new();
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_noop_option() {
+        let bytes = [super::NO_OPERATION_BYTE];
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+        let expected = AnnounceOptions::new();
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_end_option() {
+        let bytes = [super::END_OF_OPTIONS_BYTE];
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+        let expected = AnnounceOptions::new();
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_pasre_url_data_eof() {
+        let bytes = [super::URL_DATA_BYTE, 5, 0, 0, 0, 0, 0];
+        let url_data_bytes = [0, 0, 0, 0, 0];
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+        let mut expected = AnnounceOptions::new();
+        
+        let url_data = URLDataOption::new(&url_data_bytes);
+        expected.add_option(&url_data);
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_url_data_end_of_options() {
+        let bytes = [super::URL_DATA_BYTE, 5, 0, 0, 0, 0, 0, super::END_OF_OPTIONS_BYTE];
+        let url_data_bytes = [0, 0, 0, 0, 0];
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+        let mut expected = AnnounceOptions::new();
+        
+        let url_data = URLDataOption::new(&url_data_bytes);
+        expected.add_option(&url_data);
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_url_data_noop_eof() {
+        let bytes = [super::URL_DATA_BYTE, 5, 0, 0, 0, 0, 0, super::NO_OPERATION_BYTE];
+        let url_data_bytes = [0, 0, 0, 0, 0];
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+        let mut expected = AnnounceOptions::new();
+        
+        let url_data = URLDataOption::new(&url_data_bytes);
+        expected.add_option(&url_data);
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_url_data_noop_end_of_options() {
+        let bytes = [super::URL_DATA_BYTE, 5, 0, 0, 0, 0, 0, super::NO_OPERATION_BYTE, super::END_OF_OPTIONS_BYTE];
+        let url_data_bytes = [0, 0, 0, 0, 0];
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+        let mut expected = AnnounceOptions::new();
+        
+        let url_data = URLDataOption::new(&url_data_bytes);
+        expected.add_option(&url_data);
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_url_data_single_chunk() {
+        const NUM_BYTES: usize = u8::MAX as usize + 2;
+    
+        let mut bytes = [0u8; NUM_BYTES];
+        bytes[0] = super::URL_DATA_BYTE;
+        bytes[1] = u8::max_value();
+        bytes[256] = 230;
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+        let mut expected = AnnounceOptions::new();
+        
+        let url_data = URLDataOption::new(&bytes[2..]);
+        expected.add_option(&url_data);
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_url_data_two_chunks() {
+        const NUM_BYTES: usize = u8::MAX as usize + 2;
+        
+        let mut bytes = [0u8; 2 * NUM_BYTES];
+        let mut url_data_bytes = Vec::new();
+        {
+            let bytes_one = &mut bytes[..NUM_BYTES];
+            bytes_one[0] = super::URL_DATA_BYTE;
+            bytes_one[1] = u8::max_value();
+            bytes_one[256] = 230;
+            
+            url_data_bytes.extend_from_slice(&bytes_one[2..]);
+        }
+        {
+            let bytes_two = &mut bytes[NUM_BYTES..];
+            bytes_two[0] = super::URL_DATA_BYTE;
+            bytes_two[1] = u8::max_value();
+            bytes_two[256] = 210;
+            
+            url_data_bytes.extend_from_slice(&bytes_two[2..]);
+        }
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+        let mut expected = AnnounceOptions::new();
+        
+        let url_data = URLDataOption::new(&url_data_bytes[..]);
+        expected.add_option(&url_data);
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    
+    #[test]
+    fn positive_parse_url_data_undivisible_chunks() {
+        const NUM_BYTES: usize = u8::MAX as usize + 2;
+        
+        // Add an option tag, length, and a single byte as the payload to create an undivisible
+        // chunk (not evenly divisible by u8::MAX) to see if it serializes correctly.
+        let mut bytes = [0u8; NUM_BYTES + 3];
+        let mut url_data_bytes = Vec::new();
+        {
+            let bytes_one = &mut bytes[..NUM_BYTES];
+            bytes_one[0] = super::URL_DATA_BYTE;
+            bytes_one[1] = u8::max_value();
+            bytes_one[256] = 230;
+            
+            url_data_bytes.extend_from_slice(&bytes_one[2..]);
+        }
+        {
+            let bytes_two = &mut bytes[NUM_BYTES..];
+            bytes_two[0] = super::URL_DATA_BYTE;
+            bytes_two[1] = 1;
+            bytes_two[2] = 210;
+            
+            url_data_bytes.extend_from_slice(&bytes_two[2..]);
+        }
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+        let mut expected = AnnounceOptions::new();
+        
+        let url_data = URLDataOption::new(&url_data_bytes[..]);
+        expected.add_option(&url_data);
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn negative_parse_url_data_incomplete() {
+        let bytes = [super::URL_DATA_BYTE, 5, 0, 0];
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+        
+        assert!(received.is_incomplete());
+    }
+    
+    #[test]
+    fn negative_parse_url_data_unterminated() {
+        let bytes = [super::URL_DATA_BYTE, 5, 0, 0, 0, 0, 0, 60];
+        
+        let received = AnnounceOptions::from_bytes(&bytes);
+
+        assert!(received.is_incomplete());
+    }
+}

--- a/bip_utracker/src/request.rs
+++ b/bip_utracker/src/request.rs
@@ -1,0 +1,106 @@
+use std::io::{self, Write};
+
+use byteorder::{BigEndian, WriteBytesExt};
+use nom::{be_u64, be_u32, IResult};
+
+use announce::{AnnounceRequest};
+use scrape::{ScrapeRequest};
+
+// For all practical applications, this value should be hardcoded as a valid
+// connection id for connection requests when operating in server mode and processing
+// incoming requests.
+pub const CONNECT_ID_PROTOCOL_ID: u64 = 0x41727101980;
+
+/// Enumerates all types of requests that can be made to a tracker.
+pub enum RequestType<'a> {
+    Connect,
+    Announce(AnnounceRequest<'a>),
+    Scrape(ScrapeRequest<'a>)
+}
+
+/// TrackerRequest which encapsulates any request sent to a tracker.
+pub struct TrackerRequest<'a> {
+    // Both the connection id and transaction id are techinically not unsigned according
+    // to the spec, but since they are just bits we will keep them as unsigned since it
+    // doesnt really make sense to not have them as unsigned (easier to generate transactions).
+    connection_id:  u64,
+    transaction_id: u32,
+    request_type:   RequestType<'a>
+}
+
+impl<'a> TrackerRequest<'a> {
+    /// Create a new TrackerRequest.
+    pub fn new(conn_id: u64, trans_id: u32, req_type: RequestType<'a>) -> TrackerRequest<'a> {
+        TrackerRequest{ connection_id: conn_id, transaction_id: trans_id, request_type: req_type }
+    }
+    
+    /// Create a new TrackerRequest from the given bytes.
+    pub fn from_bytes(bytes: &'a [u8]) -> IResult<&'a [u8], TrackerRequest<'a>> {
+        parse_request(bytes)
+    }
+    
+    /// Write the TrackerRequest to the given writer.
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        try!(writer.write_u64::<BigEndian>(self.connection_id()));
+            
+        match self.request_type() {
+            &RequestType::Connect => {
+                try!(writer.write_u32::<BigEndian>(::CONNECT_ACTION_ID));
+                try!(writer.write_u32::<BigEndian>(self.transaction_id()));
+            },
+            &RequestType::Announce(ref req) => {
+                let action_id = if req.source_ip().is_ipv4() {
+                    ::ANNOUNCE_IPV4_ACTION_ID
+                } else { ::ANNOUNCE_IPV6_ACTION_ID };
+                try!(writer.write_u32::<BigEndian>(action_id));
+                try!(writer.write_u32::<BigEndian>(self.transaction_id()));
+                
+                try!(req.write_bytes(writer));
+            },
+            &RequestType::Scrape(ref req) => {
+                try!(writer.write_u32::<BigEndian>(::SCRAPE_ACTION_ID));
+                try!(writer.write_u32::<BigEndian>(self.transaction_id()));
+                
+                try!(req.write_bytes(writer));
+            }
+        };
+        
+        Ok(())
+    }
+    
+    /// Connection ID supplied with a request to validate the senders address.
+    ///
+    /// For Connect requests, this will always be equal to 0x41727101980. Therefore,
+    /// you should not hand out that specific ID to peers that make a connect request.
+    pub fn connection_id(&self) -> u64 {
+        self.connection_id
+    }
+    
+    /// Transaction ID supplied with a request to uniquely identify a response. 
+    pub fn transaction_id(&self) -> u32 {
+        self.transaction_id
+    }
+    
+    /// Actual type of request that this TrackerRequest represents.
+    pub fn request_type(&self) -> &RequestType {
+        &self.request_type
+    }
+}
+
+fn parse_request<'a>(bytes: &'a [u8]) -> IResult<&'a [u8], TrackerRequest<'a>> {
+    switch!(bytes, tuple!(be_u64, be_u32, be_u32),
+        (CONNECT_ID_PROTOCOL_ID, ::CONNECT_ACTION_ID, tid) => value!(
+            TrackerRequest::new(CONNECT_ID_PROTOCOL_ID, tid, RequestType::Connect)
+        ) |
+        (cid, ::ANNOUNCE_IPV4_ACTION_ID, tid) => map!(call!(AnnounceRequest::from_bytes_v4), |ann_req| {
+            TrackerRequest::new(cid, tid, RequestType::Announce(ann_req))
+        }) |
+        (cid, ::SCRAPE_ACTION_ID, tid) => map!(call!(ScrapeRequest::from_bytes), |scr_req| {
+            TrackerRequest::new(cid, tid, RequestType::Scrape(scr_req))
+        }) |
+        (cid, ::ANNOUNCE_IPV6_ACTION_ID, tid) => map!(call!(AnnounceRequest::from_bytes_v6), |ann_req| {
+            TrackerRequest::new(cid, tid, RequestType::Announce(ann_req))
+        })
+    )
+}

--- a/bip_utracker/src/response.rs
+++ b/bip_utracker/src/response.rs
@@ -1,0 +1,62 @@
+use nom::{be_u32, IResult, be_i64};
+
+use announce::{AnnounceResponse};
+use error::{ErrorResponse};
+use scrape::{ScrapeResponse};
+
+/// Error action ids only occur in responses.
+const ERROR_ACTION_ID: u32 = 3;
+
+/// Enumerates all types of responses that can be received from a tracker.
+pub enum ResponseType<'a> {
+    Connect(i64),
+    Announce(AnnounceResponse<'a>),
+    Scrape(ScrapeResponse<'a>),
+    Error(ErrorResponse<'a>)
+}
+
+/// TrackerResponse which encapsulates any response sent from a tracker.
+pub struct TrackerResponse<'a> {
+    transaction_id: u32,
+    response_type:  ResponseType<'a>
+}
+
+impl<'a> TrackerResponse<'a> {
+    /// Create a new TrackerResponse.
+    pub fn new(trans_id: u32, res_type: ResponseType<'a>) -> TrackerResponse<'a> {
+        TrackerResponse{ transaction_id: trans_id, response_type: res_type }
+    }
+    
+    /// Create a new TrackerResponse from the given bytes.
+    pub fn from_bytes(bytes: &'a [u8]) -> IResult<&'a [u8], TrackerResponse<'a>> {
+        parse_response(bytes)
+    }
+    
+    /// Transaction ID supplied with a response to uniquely identify a request. 
+    pub fn transaction_id(&self) -> u32 {
+        self.transaction_id
+    }
+    
+    /// Actual type of response that this TrackerResponse represents.
+    pub fn response_type(&self) -> &ResponseType<'a> {
+        &self.response_type
+    }
+}
+
+fn parse_response<'a>(bytes: &'a [u8]) -> IResult<&'a [u8], TrackerResponse<'a>> {
+    switch!(bytes, tuple!(be_u32, be_u32),
+        (::CONNECT_ACTION_ID, tid)  => map!(be_i64, |cid| TrackerResponse::new(tid, ResponseType::Connect(cid)) ) |
+        (::ANNOUNCE_IPV4_ACTION_ID, tid) => map!(call!(AnnounceResponse::from_bytes_v4), |ann_res| {
+            TrackerResponse::new(tid, ResponseType::Announce(ann_res))
+        }) |
+        (::SCRAPE_ACTION_ID, tid)   => map!(call!(ScrapeResponse::from_bytes), |scr_res| {
+            TrackerResponse::new(tid, ResponseType::Scrape(scr_res))
+        }) |
+        (ERROR_ACTION_ID, tid)    => map!(call!(ErrorResponse::from_bytes), |err_res| {
+            TrackerResponse::new(tid, ResponseType::Error(err_res))
+        }) |
+        (::ANNOUNCE_IPV6_ACTION_ID, tid) => map!(call!(AnnounceResponse::from_bytes_v6), |ann_req| {
+            TrackerResponse::new(tid, ResponseType::Announce(ann_req))
+        })
+    )
+}

--- a/bip_utracker/src/scrape.rs
+++ b/bip_utracker/src/scrape.rs
@@ -1,0 +1,425 @@
+use std::borrow::{Cow};
+use std::io::{self, Write};
+
+use bip_util::bt::{self, InfoHash};
+use bip_util::convert::{self};
+use nom::{IResult, Needed, be_i32};
+
+const SCRAPE_STATS_BYTES: usize = 12;
+
+/// Status for a given InfoHash.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ScrapeStats {
+    seeders:    i32,
+    downloaded: i32,
+    leechers:   i32
+}
+
+impl ScrapeStats {
+    /// Create a new ScrapeStats.
+    pub fn new(seeders: i32, downloaded: i32, leechers: i32) -> ScrapeStats {
+        ScrapeStats{ seeders: seeders, downloaded: downloaded, leechers: leechers }
+    }
+    
+    /// Construct a ScrapeStats from the given bytes.
+    fn from_bytes(bytes: &[u8]) -> IResult<&[u8], ScrapeStats> {
+        parse_stats(bytes)
+    }
+    
+    /// Current number of seeders.
+    pub fn num_seeders(&self) -> i32 {
+        self.seeders
+    }
+    
+    /// Number of times it has been downloaded.
+    pub fn num_downloads(&self) -> i32 {
+        self.downloaded
+    }
+    
+    /// Current number of leechers.
+    pub fn num_leechers(&self) -> i32 {
+        self.leechers
+    }
+}
+
+fn parse_stats(bytes: &[u8]) -> IResult<&[u8], ScrapeStats> {
+    chain!(bytes,
+        seeders:    be_i32 ~
+        downloaded: be_i32 ~
+        leechers:   be_i32 ,
+        || { ScrapeStats::new(seeders, downloaded, leechers) }
+    )
+}
+
+//----------------------------------------------------------------------------//
+
+/// Scrape request sent from the client to the server.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScrapeRequest<'a> {
+    hashes: Cow<'a, [u8]>
+}
+
+impl<'a> ScrapeRequest<'a> {
+    /// Create a new ScrapeRequest.
+    pub fn new() -> ScrapeRequest<'a> {
+        ScrapeRequest{ hashes: Cow::Owned(Vec::new()) }
+    }
+    
+    /// Construct a ScrapeRequest from the given bytes.
+    pub fn from_bytes(bytes: &'a [u8]) -> IResult<&'a [u8], ScrapeRequest<'a>> {
+        parse_request(bytes)
+    }
+    
+    /// Write the ScrapeRequest to the given writer.
+    ///
+    /// Ordering of the written InfoHash is identical to that of ScrapeRequest::iter().
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        writer.write_all(&*self.hashes)
+    }
+    
+    /// Add the InfoHash to the current request.
+    pub fn insert(&mut self, hash: InfoHash) {
+        let hash_bytes: [u8; bt::INFO_HASH_LEN] = hash.into();
+        
+        self.hashes.to_mut().extend_from_slice(&hash_bytes);
+    }
+    
+    /// Iterator over all of the hashes in the request.
+    pub fn iter<'b>(&'b self) -> ScrapeRequestIter<'b> {
+        ScrapeRequestIter::new(&*self.hashes)
+    }
+}
+
+fn parse_request<'a>(bytes: &'a [u8]) -> IResult<&'a [u8], ScrapeRequest<'a>> {
+    let remainder_bytes = bytes.len() % bt::INFO_HASH_LEN;
+    
+    if remainder_bytes != 0 {
+        IResult::Incomplete(Needed::Size(bt::INFO_HASH_LEN - remainder_bytes))
+    } else {
+        let end_of_bytes = &bytes[bytes.len()..bytes.len()];
+        
+        IResult::Done(end_of_bytes, ScrapeRequest{ hashes: Cow::Borrowed(bytes) })
+    }
+}
+
+//----------------------------------------------------------------------------//
+
+/// Scrape response sent from the server to the client.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScrapeResponse<'a> {
+    stats: Cow<'a, [u8]>
+}
+
+impl<'a> ScrapeResponse<'a> {
+    /// Create a new ScrapeResponse.
+    pub fn new() -> ScrapeResponse<'a> {
+        ScrapeResponse{ stats: Cow::Owned(Vec::new()) }
+    }
+    
+    /// Construct a ScrapeResponse from the given bytes.
+    pub fn from_bytes(bytes: &'a [u8]) -> IResult<&'a [u8], ScrapeResponse<'a>> {
+        parse_response(bytes)
+    }
+    
+    /// Write the ScrapeResponse to the given writer.
+    ///
+    /// Ordering of the written stats is identical to that of ScrapeResponse::iter().
+    pub fn write_bytes<W>(&self, mut writer: W) -> io::Result<()>
+        where W: Write {
+        writer.write_all(&*self.stats)
+    }
+    
+    /// Add the scrape statistics to the current response.
+    pub fn insert(&mut self, stats: ScrapeStats) {
+        let seeders_bytes = convert::four_bytes_to_array(stats.num_seeders() as u32);
+        let downloads_bytes = convert::four_bytes_to_array(stats.num_downloads() as u32);
+        let leechers_bytes = convert::four_bytes_to_array(stats.num_leechers() as u32);
+        
+        self.stats.to_mut().reserve(SCRAPE_STATS_BYTES);
+        
+        self.stats.to_mut().extend_from_slice(&seeders_bytes);
+        self.stats.to_mut().extend_from_slice(&downloads_bytes);
+        self.stats.to_mut().extend_from_slice(&leechers_bytes);
+    }
+    
+    /// Iterator over each status for every InfoHash in the request.
+    ///
+    /// Ordering of the status corresponds to the ordering of the InfoHash in the
+    /// initial request.
+    pub fn iter<'b>(&'b self) -> ScrapeResponseIter<'b> {
+        ScrapeResponseIter::new(&*self.stats)
+    }
+}
+
+fn parse_response<'a>(bytes: &'a [u8]) -> IResult<&'a [u8], ScrapeResponse<'a>> {
+    let remainder_bytes = bytes.len() % SCRAPE_STATS_BYTES;
+    
+    if remainder_bytes != 0 {
+        IResult::Incomplete(Needed::Size(SCRAPE_STATS_BYTES - remainder_bytes))
+    } else {
+        let end_of_bytes = &bytes[bytes.len()..bytes.len()];
+        
+        IResult::Done(end_of_bytes, ScrapeResponse{ stats: Cow::Borrowed(bytes) })
+    }
+}
+
+//----------------------------------------------------------------------------//
+
+/// Iterator over a number of InfoHashes.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ScrapeRequestIter<'a> {
+    hashes: &'a [u8],
+    offset: usize
+}
+
+impl<'a> ScrapeRequestIter<'a> {
+    fn new(bytes: &'a [u8]) -> ScrapeRequestIter<'a> {
+        ScrapeRequestIter{ hashes: bytes, offset: 0 }
+    }
+}
+
+impl<'a> Iterator for ScrapeRequestIter<'a> {
+    type Item = InfoHash;
+    
+    fn next(&mut self) -> Option<InfoHash> {
+        if self.offset == self.hashes.len() {
+            None
+        } else {
+            let (start, end) = (self.offset, self.offset + bt::INFO_HASH_LEN);
+            self.offset = end;
+            
+            Some(InfoHash::from_hash(&self.hashes[start..end]).unwrap())
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for ScrapeRequestIter<'a> {
+    fn len(&self) -> usize {
+        self.hashes.len() / bt::INFO_HASH_LEN
+    }
+}
+
+//----------------------------------------------------------------------------//
+
+/// Iterator over a number of ScrapeStats.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ScrapeResponseIter<'a> {
+    stats:  &'a [u8],
+    offset: usize
+}
+
+impl<'a> ScrapeResponseIter<'a> {
+    fn new(bytes: &'a [u8]) -> ScrapeResponseIter<'a> {
+        ScrapeResponseIter{ stats: bytes, offset: 0 }
+    }
+}
+
+impl<'a> Iterator for ScrapeResponseIter<'a> {
+    type Item = ScrapeStats;
+    
+    fn next(&mut self) -> Option<ScrapeStats> {
+        if self.offset == self.stats.len() {
+            None
+        } else {
+            let (start, end) = (self.offset, self.offset + SCRAPE_STATS_BYTES);
+            self.offset = end;
+            
+            match ScrapeStats::from_bytes(&self.stats[start..end]) {
+                IResult::Done(_, stats) => Some(stats),
+                _                       => panic!("Bug In ScrapeResponseIter Caused ScrapeStats Parsing To Fail...")
+            }
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for ScrapeResponseIter<'a> {
+    fn len(&self) -> usize {
+        self.stats.len() / SCRAPE_STATS_BYTES
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bip_util::bt::{self};
+    use byteorder::{BigEndian, WriteBytesExt};
+    use nom::{IResult};
+    
+    use super::{ScrapeRequest, ScrapeResponse, ScrapeStats};
+    
+    #[test]
+    fn positive_write_request_empty() {
+        let mut received = Vec::new();
+        
+        let request = ScrapeRequest::new();
+        request.write_bytes(&mut received).unwrap();
+        
+        let expected = [];
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_request_single_hash() {
+        let mut received = Vec::new();
+        
+        let expected = [1u8; bt::INFO_HASH_LEN];
+        
+        let mut request = ScrapeRequest::new();
+        request.insert(expected.into());
+        request.write_bytes(&mut received).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_request_many_hashes() {
+        let mut received = Vec::new();
+        
+        let hash_one = [1u8; bt::INFO_HASH_LEN];
+        let hash_two = [34u8; bt::INFO_HASH_LEN];
+        
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&hash_one);
+        expected.extend_from_slice(&hash_two);
+        
+        let mut request = ScrapeRequest::new();
+        request.insert(hash_one.into());
+        request.insert(hash_two.into());
+        request.write_bytes(&mut received).unwrap();
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_response_empty() {
+        let mut received = Vec::new();
+        
+        let response = ScrapeResponse::new();
+        response.write_bytes(&mut received).unwrap();
+        
+        let expected = [];
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_response_single_stat() {
+        let mut received = Vec::new();
+        
+        let stat_one = ScrapeStats::new(1234, 2342, 0);
+        
+        let mut response = ScrapeResponse::new();
+        response.insert(stat_one);
+        response.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_i32::<BigEndian>(stat_one.num_seeders());
+        expected.write_i32::<BigEndian>(stat_one.num_downloads());
+        expected.write_i32::<BigEndian>(stat_one.num_leechers());
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_write_response_many_stats() {
+        let mut received = Vec::new();
+        
+        let stat_one = ScrapeStats::new(1234, 2342, 0);
+        let stat_two = ScrapeStats::new(3333, -23, -2323);
+        
+        let mut response = ScrapeResponse::new();
+        response.insert(stat_one);
+        response.insert(stat_two);
+        response.write_bytes(&mut received).unwrap();
+        
+        let mut expected = Vec::new();
+        expected.write_i32::<BigEndian>(stat_one.num_seeders());
+        expected.write_i32::<BigEndian>(stat_one.num_downloads());
+        expected.write_i32::<BigEndian>(stat_one.num_leechers());
+        
+        expected.write_i32::<BigEndian>(stat_two.num_seeders());
+        expected.write_i32::<BigEndian>(stat_two.num_downloads());
+        expected.write_i32::<BigEndian>(stat_two.num_leechers());
+        
+        assert_eq!(&received[..], &expected[..]);
+    }
+    
+    #[test]
+    fn positive_parse_request_empty() {
+        let hash_one = [];
+        
+        let received = ScrapeRequest::from_bytes(&hash_one);
+        
+        let mut expected = ScrapeRequest::new();
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_request_single_hash() {
+        let hash_one = [1u8; bt::INFO_HASH_LEN];
+        
+        let received = ScrapeRequest::from_bytes(&hash_one);
+        
+        let mut expected = ScrapeRequest::new();
+        expected.insert(hash_one.into());
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_request_multiple_hashes() {
+        let hash_one = [1u8; bt::INFO_HASH_LEN];
+        let hash_two = [5u8; bt::INFO_HASH_LEN];
+        
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&hash_one);
+        bytes.extend_from_slice(&hash_two);
+        
+        let received = ScrapeRequest::from_bytes(&bytes);
+        
+        let mut expected = ScrapeRequest::new();
+        expected.insert(hash_one.into());
+        expected.insert(hash_two.into());
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_response_empty() {
+        let stats_bytes = [];
+        
+        let received = ScrapeResponse::from_bytes(&stats_bytes);
+        
+        let expected = ScrapeResponse::new();
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_response_single_stat() {
+        let stats_bytes = [0, 0, 0, 255, 0, 0, 1, 0, 0, 0, 2, 0];
+        
+        let received = ScrapeResponse::from_bytes(&stats_bytes);
+        
+        let mut expected = ScrapeResponse::new();
+        expected.insert(ScrapeStats::new(255, 256, 512));
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+    
+    #[test]
+    fn positive_parse_response_many_stats() {
+        let stats_bytes = [0, 0, 0, 255, 0, 0, 1, 0, 0, 0, 2, 0,
+            0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3];
+        
+        let received = ScrapeResponse::from_bytes(&stats_bytes);
+        
+        let mut expected = ScrapeResponse::new();
+        expected.insert(ScrapeStats::new(255, 256, 512));
+        expected.insert(ScrapeStats::new(1, 2, 3));
+        
+        assert_eq!(received, IResult::Done(&b""[..], expected));
+    }
+}

--- a/bip_utracker/src/transaction.rs
+++ b/bip_utracker/src/transaction.rs
@@ -1,0 +1,60 @@
+use std::u32::{self};
+
+use bip_util::{self};
+
+const MAX_TRANSACTION_ID: u32 = u32::MAX;
+
+// NEEDS TO FIT IN A u32
+const TRANSACTION_ID_PREALLOC_LEN: usize = 2048;
+
+pub struct TIDGenerator {
+    next_alloc:      u32,
+    curr_index:      usize,
+    transaction_ids: [u32; TRANSACTION_ID_PREALLOC_LEN]
+}
+
+impl TIDGenerator {
+    pub fn new() -> TIDGenerator {
+        let (next_alloc, mut transaction_ids) = generate_tids(0);
+        
+        bip_util::fisher_shuffle(&mut transaction_ids);
+        
+        TIDGenerator{ next_alloc: next_alloc, curr_index: 0, transaction_ids: transaction_ids }
+    }
+    
+    pub fn generate(&mut self) -> u32 {
+        let opt_transaction_id = self.transaction_ids.get(self.curr_index).map(|t| *t);
+        
+        if let Some(transaction_id) = opt_transaction_id {
+            self.curr_index += 1;
+            
+            transaction_id
+        } else {
+            let (next_alloc, mut transaction_ids) = generate_tids(self.next_alloc);
+            
+            bip_util::fisher_shuffle(&mut transaction_ids);
+            
+            self.next_alloc = next_alloc;
+            self.transaction_ids = transaction_ids;
+            self.curr_index = 0;
+            
+            self.generate()
+        }
+    }
+}
+
+fn generate_tids(next_alloc: u32) -> (u32, [u32; TRANSACTION_ID_PREALLOC_LEN]) {
+    // Check if we need to wrap
+    let (next_alloc_start, next_alloc_end) = if next_alloc == MAX_TRANSACTION_ID {
+        (0, TRANSACTION_ID_PREALLOC_LEN as u32)
+    } else {
+        (next_alloc, next_alloc + TRANSACTION_ID_PREALLOC_LEN as u32)
+    };
+    let mut transaction_ids = [0u32; TRANSACTION_ID_PREALLOC_LEN];
+    
+    for (index, transaction_id) in (next_alloc_start..next_alloc_end).enumerate() {
+        transaction_ids[index] = transaction_id;
+    }
+    
+    (next_alloc_end, transaction_ids)
+}


### PR DESCRIPTION
Current implementation has a lot of code additions so I think it is best to merge those now.

A new branch will be made to work on the networking code for the crate.
