### PR TITLE
Eliminate Additive Buffer Count For Metainfo Workers; Bump bip_metain…

### DIFF
--- a/bip_metainfo/Cargo.toml
+++ b/bip_metainfo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "bip_metainfo"
-version       = "0.4.1"
+version       = "0.4.2"
 description   = "Parsing and building of bittorrent metainfo files"
 
 authors       = ["Andrew <amiller4421@gmail.com>"]

--- a/bip_metainfo/src/builder/buffer.rs
+++ b/bip_metainfo/src/builder/buffer.rs
@@ -4,7 +4,7 @@ use crossbeam::sync::{MsQueue};
 
 // Ensures that we have enough buffers to keep workers busy.
 const TOTAL_BUFFERS_MULTIPLICATIVE: usize = 2;
-const TOTAL_BUFFERS_ADDITIVE:       usize = 4;
+const TOTAL_BUFFERS_ADDITIVE:       usize = 0;
 
 /// Stores a set number of piece buffers to be used and re-used.
 pub struct PieceBuffers {


### PR DESCRIPTION
…fo Patch Version

Memory usage with the additive buffers is very high and seems to give little to no benefit in terms of hashing performance. With two threads, this change cuts memory usage in half but maintains similar (exactly the same from what I can tell) performance.

Will investigate memory usage for building metainfo files further in the future as with two threads and a 2MB piece length, we should see roughly an additional 8MB in memory usage but while playing around with the `create_torrent` example, I am seeing much higher than that (~1MB which jumps to ~33MB when the program starts building the file).
