### PR TITLE
Add FileHandleCache To Speed Up Opening Files Via FileSystem

### DIFF
--- a/bip_disk/Cargo.toml
+++ b/bip_disk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name             = "bip_disk"
-version          = "0.1.0"
+version          = "0.2.0"
 description      = "Bittorrent Infrastructure Project Disk Module"
 
 authors          = ["Andrew <amiller4421@gmail.com>"]
@@ -19,6 +19,7 @@ futures          = "0.1"
 futures-cpupool  = "0.1"
 error-chain      = "0.10"
 log              = "0.3"
+lru-cache        = "0.1"
 tokio-core       = "0.1"
 
 [dev-dependencies]

--- a/bip_disk/benches/mod.rs
+++ b/bip_disk/benches/mod.rs
@@ -11,6 +11,7 @@ mod benches {
     use std::fs;
 
     use bip_disk::fs::NativeFileSystem;
+    use bip_disk::fs_cache::FileHandleCache;
     use bip_disk::{DiskManagerBuilder, IDiskMessage, ODiskMessage, InfoHash, Block, BlockMetadata, FileSystem};
     use bip_metainfo::{DirectAccessor, MetainfoBuilder, MetainfoFile, PieceLength};
     use futures::stream::{self, Stream};
@@ -155,6 +156,51 @@ mod benches {
             let _ = fs::remove_dir_all(data_directory);
         }
         let filesystem = NativeFileSystem::with_directory(data_directory);
+
+        bench_process_file_with_fs(b, piece_length, block_length, file_length, filesystem);
+    }
+
+    #[bench]
+    fn bench_file_handle_cache_fs_1_mb_pieces_128_kb_blocks(b: &mut Bencher) {
+        let piece_length = 1 * 1024 * 1024;
+        let block_length = 128 * 1024;
+        let file_length = 2 * 1024 * 1024;
+        let data_directory = "target/bench_data/bench_native_fs_1_mb_pieces_128_kb_blocks";
+
+        if WIPE_DATA_DIR {
+            let _ = fs::remove_dir_all(data_directory);
+        }
+        let filesystem = FileHandleCache::new(NativeFileSystem::with_directory(data_directory), 1);
+
+        bench_process_file_with_fs(b, piece_length, block_length, file_length, filesystem);
+    }
+
+    #[bench]
+    fn bench_file_handle_cache_fs_1_mb_pieces_16_kb_blocks(b: &mut Bencher) {
+        let piece_length = 1 * 1024 * 1024;
+        let block_length = 16 * 1024;
+        let file_length = 2 * 1024 * 1024;
+        let data_directory = "target/bench_data/bench_native_fs_1_mb_pieces_16_kb_blocks";
+
+        if WIPE_DATA_DIR {
+            let _ = fs::remove_dir_all(data_directory);
+        }
+        let filesystem = FileHandleCache::new(NativeFileSystem::with_directory(data_directory), 1);
+
+        bench_process_file_with_fs(b, piece_length, block_length, file_length, filesystem);
+    }
+
+    #[bench]
+    fn bench_file_handle_cache_fs_1_mb_pieces_2_kb_blocks(b: &mut Bencher) {
+        let piece_length = 1 * 1024 * 1024;
+        let block_length = 2 * 1024;
+        let file_length = 2 * 1024 * 1024;
+        let data_directory = "target/bench_data/bench_native_fs_1_mb_pieces_2_kb_blocks";
+
+        if WIPE_DATA_DIR {
+            let _ = fs::remove_dir_all(data_directory);
+        }
+        let filesystem = FileHandleCache::new(NativeFileSystem::with_directory(data_directory), 1);
 
         bench_process_file_with_fs(b, piece_length, block_length, file_length, filesystem);
     }

--- a/bip_disk/src/disk/fs/cache/file_handle.rs
+++ b/bip_disk/src/disk/fs/cache/file_handle.rs
@@ -1,0 +1,84 @@
+use std::sync::{Arc, Mutex};
+use std::path::{PathBuf, Path};
+use std::io;
+
+use disk::fs::FileSystem;
+
+use lru_cache::LruCache;
+
+/// Caches file handles to prevent going to the OS for every call to open a file.
+///
+/// This is especially useful for consumer computers that have anti-virus software
+/// installed, which will significantly increase the cost for opening any files
+/// (with windows built in anti virus, I saw 20x slow downs).
+pub struct FileHandleCache<F> where F: FileSystem {
+    cache: Mutex<LruCache<PathBuf, Arc<Mutex<F::File>>>>,
+    inner: F
+}
+
+impl<F> FileHandleCache<F> where F: FileSystem {
+    /// Create a new `FileHandleCache` with the given handle capacity and an
+    /// inner `FileSystem` which will be called for handles not in the cache.
+    pub fn new(inner: F, capacity: usize) -> FileHandleCache<F> {
+        FileHandleCache{ cache: Mutex::new(LruCache::new(capacity)), inner: inner }
+    }
+
+    fn run_with_lock<C, R>(&self, call: C) -> R
+        where C: FnOnce(&mut LruCache<PathBuf, Arc<Mutex<F::File>>>, &F) -> R {
+        let mut lock_cache = self.cache.lock()
+            .expect("bip_disk: Failed To Lock Cache In FileHandleCache::run_with_lock");
+
+        call(&mut *lock_cache, &self.inner)
+    }
+}
+
+impl<F> FileSystem for FileHandleCache<F> where F: FileSystem {
+    type File = Arc<Mutex<F::File>>;
+
+    fn open_file<P>(&self, path: P) -> io::Result<Self::File>
+        where P: AsRef<Path> + Send + 'static {
+        self.run_with_lock(|cache, fs| {
+            {
+                if let Some(entry) = cache.get_mut(path.as_ref()) {
+                    return Ok(entry.clone())
+                }
+            }
+            let path_buf = path.as_ref().to_path_buf();
+            let file = Arc::new(Mutex::new(try!(fs.open_file(path))));
+
+            cache.insert(path_buf, file.clone());
+
+            Ok(file)
+        })
+    }
+
+    fn sync_file<P>(&self, _path: P) -> io::Result<()>
+        where P: AsRef<Path> + Send + 'static {
+        self.run_with_lock(|cache, _| {
+            cache.clear()
+        });
+
+        Ok(())
+    }
+
+    fn file_size(&self, file: &Self::File) -> io::Result<u64> {
+        let lock_file = file.lock()
+        .expect("bip_disk: Failed To Lock File In FileHandleCache::file_size");
+
+        self.inner.file_size(&*lock_file)
+    }
+
+    fn read_file(&self, file: &mut Self::File, offset: u64, buffer: &mut [u8]) -> io::Result<usize> {
+        let mut lock_file = file.lock()
+            .expect("bip_disk: Failed To Lock File In FileHandleCache::read_file");
+
+        self.inner.read_file(&mut *lock_file, offset, buffer)
+    }
+
+    fn write_file(&self, file: &mut Self::File, offset: u64, buffer: &[u8]) -> io::Result<usize> {
+        let mut lock_file = file.lock()
+            .expect("bip_disk: Failed To Lock File In FileHandleCache::write_file");
+
+        self.inner.write_file(&mut *lock_file, offset, buffer)
+    }
+}

--- a/bip_disk/src/disk/fs/cache/file_handle.rs
+++ b/bip_disk/src/disk/fs/cache/file_handle.rs
@@ -52,13 +52,13 @@ impl<F> FileSystem for FileHandleCache<F> where F: FileSystem {
         })
     }
 
-    fn sync_file<P>(&self, _path: P) -> io::Result<()>
+    fn sync_file<P>(&self, path: P) -> io::Result<()>
         where P: AsRef<Path> + Send + 'static {
         self.run_with_lock(|cache, _| {
             cache.clear()
         });
 
-        Ok(())
+        self.inner.sync_file(path)
     }
 
     fn file_size(&self, file: &Self::File) -> io::Result<u64> {

--- a/bip_disk/src/disk/fs/cache/mod.rs
+++ b/bip_disk/src/disk/fs/cache/mod.rs
@@ -1,0 +1,1 @@
+pub mod file_handle;

--- a/bip_disk/src/disk/fs/mod.rs
+++ b/bip_disk/src/disk/fs/mod.rs
@@ -1,6 +1,7 @@
 use std::path::{Path};
 use std::io::{self};
 
+pub mod cache;
 pub mod native;
 
 /// Trait for performing operations on some file system.
@@ -16,11 +17,12 @@ pub trait FileSystem {
     fn open_file<P>(&self, path: P) -> io::Result<Self::File>
         where P: AsRef<Path> + Send + 'static;
 
+    /// Sync the file.
+    fn sync_file<P>(&self, path: P) -> io::Result<()>
+        where P: AsRef<Path> + Send + 'static;
+
     /// Get the size of the file in bytes.
     fn file_size(&self, file: &Self::File) -> io::Result<u64>;
-
-    /// Remove a given file from the file system.
-    fn remove_file(&self, file: Self::File) -> io::Result<()>;
 
     /// Read the contents of the file at the given offset.
     ///
@@ -42,12 +44,13 @@ impl<'a, F> FileSystem for &'a F where F: FileSystem {
         FileSystem::open_file(*self, path)
     }
 
-    fn file_size(&self, file: &Self::File) -> io::Result<u64> {
-        FileSystem::file_size(*self, file)
+    fn sync_file<P>(&self, path: P) -> io::Result<()>
+        where P: AsRef<Path> + Send + 'static {
+        FileSystem::sync_file(*self, path)
     }
 
-    fn remove_file(&self, file: Self::File) -> io::Result<()> {
-        FileSystem::remove_file(*self, file)
+    fn file_size(&self, file: &Self::File) -> io::Result<u64> {
+        FileSystem::file_size(*self, file)
     }
 
     fn read_file(&self, file: &mut Self::File, offset: u64, buffer: &mut [u8]) -> io::Result<usize> {

--- a/bip_disk/src/disk/fs/native.rs
+++ b/bip_disk/src/disk/fs/native.rs
@@ -9,14 +9,13 @@ use disk::fs::FileSystem;
 
 /// File that exists on disk.
 pub struct NativeFile {
-    file: File,
-    path: PathBuf,
+    file: File
 }
 
 impl NativeFile {
     /// Create a new NativeFile.
-    fn new(file: File, path: PathBuf) -> NativeFile {
-        NativeFile{ file: file, path: path }
+    fn new(file: File) -> NativeFile {
+        NativeFile{ file: file }
     }
 }
 
@@ -41,15 +40,16 @@ impl FileSystem for NativeFileSystem {
         let combine_path = combine_user_path(&path, &self.current_dir);
         let file = try!(create_new_file(&combine_path));
 
-        Ok(NativeFile::new(file, combine_path.into_owned()))
+        Ok(NativeFile::new(file))
+    }
+
+    fn sync_file<P>(&self, _path: P) -> io::Result<()>
+        where P: AsRef<Path> + Send + 'static {
+        Ok(())
     }
 
     fn file_size(&self, file: &NativeFile) -> io::Result<u64> {
         file.file.metadata().map(|metadata| metadata.len())
-    }
-
-    fn remove_file(&self, file: NativeFile) -> io::Result<()> {
-        fs::remove_file(&file.path)
     }
 
     fn read_file(&self, file: &mut NativeFile, offset: u64, buffer: &mut [u8]) -> io::Result<usize> {

--- a/bip_disk/src/disk/mod.rs
+++ b/bip_disk/src/disk/mod.rs
@@ -18,8 +18,21 @@ pub enum IDiskMessage {
     AddTorrent(MetainfoFile),
     /// Message to remove a torrent from the disk manager.
     ///
-    /// Note, this will NOT remove any data from the `FileSystem`.
+    /// Note, this will NOT remove any data from the `FileSystem`,
+    /// and as an added convenience, this message will also trigger
+    /// a `IDiskMessage::SyncTorrent` message.
     RemoveTorrent(InfoHash),
+    /// Message to tell the `FileSystem` to sync the torrent.
+    ///
+    /// This message will trigger a call to `FileSystem::sync` for every
+    /// file in the torrent, so the semantics will differ depending on the
+    /// `FileSystem` in use.
+    ///
+    /// In general, if a torrent has finished downloading, but will be kept
+    /// in the `DiskManager` to, for example, seed the torrent, then this
+    /// message should be sent, otherwise, `IDiskMessage::RemoveTorrent` is
+    /// sufficient.
+    SyncTorrent(InfoHash),
     /// Message to load the given block in to memory.
     LoadBlock(Block),
     /// Message to process the given block and persist it.
@@ -34,8 +47,10 @@ pub enum ODiskMessage {
     /// Any good pieces already existing for the torrent will be sent
     /// as `FoundGoodPiece` messages BEFORE this message is sent.
     TorrentAdded(InfoHash),
-    /// Message indicating the the torrent has been removed.
+    /// Message indicating that the torrent has been removed.
     TorrentRemoved(InfoHash),
+    /// Message indicating that the torrent has been synced.
+    TorrentSynced(InfoHash),
     /// Message indicating that a good piece has been identified for
     /// the given torrent (hash), as well as the piece index.
     FoundGoodPiece(InfoHash, u64),

--- a/bip_disk/src/disk/tasks/helpers/mod.rs
+++ b/bip_disk/src/disk/tasks/helpers/mod.rs
@@ -5,7 +5,7 @@ use bip_metainfo::File;
 pub mod piece_accessor;
 pub mod piece_checker;
 
-fn build_path(parent_directory: Option<&Path>, file: &File) -> PathBuf {
+pub fn build_path(parent_directory: Option<&Path>, file: &File) -> PathBuf {
     match parent_directory {
         Some(dir) => PathBuf::from(dir).join(file.path()),
         None      => file.path().to_owned()

--- a/bip_disk/src/lib.rs
+++ b/bip_disk/src/lib.rs
@@ -6,6 +6,7 @@ extern crate futures;
 extern crate futures_cpupool;
 #[macro_use]
 extern crate log;
+extern crate lru_cache;
 extern crate tokio_core;
 
 mod disk;
@@ -24,6 +25,11 @@ pub use memory::block::{Block, BlockMetadata};
 /// Built in objects implementing `FileSystem`.
 pub mod fs {
     pub use disk::fs::native::{NativeFile, NativeFileSystem};
+}
+
+/// Built in objects implementing `FileSystem` for caching.
+pub mod fs_cache {
+    pub use disk::fs::cache::file_handle::FileHandleCache;
 }
 
 pub use bip_util::bt::InfoHash;

--- a/bip_disk/test/mod.rs
+++ b/bip_disk/test/mod.rs
@@ -170,18 +170,15 @@ impl FileSystem for InMemoryFileSystem {
         Ok(InMemoryFile{ path: file_path })
     }
 
+    fn sync_file<P>(&self, _path: P) -> io::Result<()>
+        where P: AsRef<Path> + Send + 'static {
+        Ok(())
+    }
+
     fn file_size(&self, file: &Self::File) -> io::Result<u64> {
         self.run_with_lock(|files| {
             files.get(&file.path)
                 .map(|file| file.len() as u64)
-                .ok_or(io::Error::new(io::ErrorKind::NotFound, "File Not Found"))
-        })
-    }
-
-    fn remove_file(&self, file: Self::File) -> io::Result<()> {
-        self.run_with_lock(|files| {
-            files.remove(&file.path)
-                .map(|_| ())
                 .ok_or(io::Error::new(io::ErrorKind::NotFound, "File Not Found"))
         })
     }


### PR DESCRIPTION
Todo: Add unit tests for FileHandleCache (probably no integ tests for FileSystem::sync just yet, since it is `FileSystem` dependent).