### PR TITLE
Add Backpressure For Number Of Peers In Peer Manager; Correctly Deriv…

### DIFF
--- a/bip_peer/src/manager/builder.rs
+++ b/bip_peer/src/manager/builder.rs
@@ -7,6 +7,7 @@ use futures::sink::Sink;
 use futures::stream::Stream;
 use tokio_core::reactor::Handle;
 
+const DEFAULT_PEER_CAPACITY:             usize = 1000;
 const DEFAULT_SINK_BUFFER_CAPACITY:      usize = 100;
 const DEFAULT_STREAM_BUFFER_CAPACITY:    usize = 100;
 const DEFAULT_HEARTBEAT_INTERVAL_MILLIS: u64   = 1 * 60 * 1000;
@@ -15,6 +16,7 @@ const DEFAULT_HEARTBEAT_TIMEOUT_MILLIS:  u64   = 2 * 60 * 1000;
 /// Builder for configuring a `PeerManager`.
 #[derive(Copy, Clone)]
 pub struct PeerManagerBuilder {
+    peer:               usize,
     sink_buffer:        usize,
     stream_buffer:      usize,
     heartbeat_interval: Duration,
@@ -25,11 +27,18 @@ impl PeerManagerBuilder {
     /// Create a new `PeerManagerBuilder`.
     pub fn new() -> PeerManagerBuilder {
         PeerManagerBuilder {
+            peer:               DEFAULT_PEER_CAPACITY,
             sink_buffer:        DEFAULT_SINK_BUFFER_CAPACITY,
             stream_buffer:      DEFAULT_STREAM_BUFFER_CAPACITY,
             heartbeat_interval: Duration::from_millis(DEFAULT_HEARTBEAT_INTERVAL_MILLIS),
             heartbeat_timeout:  Duration::from_millis(DEFAULT_HEARTBEAT_TIMEOUT_MILLIS)
         }
+    }
+
+    /// Max number of peers we can manage.
+    pub fn with_peer_capacity(mut self, capacity: usize) -> PeerManagerBuilder {
+        self.peer = capacity;
+        self
     }
 
     /// Capacity of pending sent messages.
@@ -54,6 +63,11 @@ impl PeerManagerBuilder {
     pub fn with_heartbeat_timeout(mut self, timeout: Duration) -> PeerManagerBuilder {
         self.heartbeat_timeout = timeout;
         self
+    }
+
+    /// Retrieve the peer capacity.
+    pub fn peer_capacity(&self) -> usize {
+        self.peer
     }
 
     /// Retrieve the sink buffer capacity.

--- a/bip_peer/src/manager/future/mod.rs
+++ b/bip_peer/src/manager/future/mod.rs
@@ -15,7 +15,7 @@ pub enum PersistentError {
 impl<T> From<TimeoutError<T>> for PersistentError {
     fn from(error: TimeoutError<T>) -> PersistentError {
         match error {
-            TimeoutError::Timer(_, _) => panic!("bip_peer: Timer Error In Peer Stream, Timer Capacity Is Probably Too Small..."),
+            TimeoutError::Timer(_, err) => panic!("bip_peer: Timer Error In Peer Stream, Timer Capacity Is Probably Too Small: {}", err),
             TimeoutError::TimedOut(_) => PersistentError::Timeout
         }
     }

--- a/bip_peer/src/manager/future/mod.rs
+++ b/bip_peer/src/manager/future/mod.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::time::Duration;
 
-use tokio_timer::{Timer, TimeoutError, TimeoutStream, Sleep};
+use tokio_timer::{Timer, TimeoutError, Sleep};
 use futures::{Poll, Async, Future};
 use futures::stream::{Stream, Fuse};
 

--- a/bip_peer/src/manager/mod.rs
+++ b/bip_peer/src/manager/mod.rs
@@ -55,7 +55,7 @@ impl<P> PeerManager<P>
         // Figure out the right tick duration to get num slots of 2048.
         // TODO: We could probably let users change this in the future...
         let max_duration = cmp::max(builder.heartbeat_interval(), builder.heartbeat_timeout());
-        let tick_duration = Duration::from_millis(max_duration.as_secs() * 1000 / DEFAULT_TIMER_SLOTS + 1);
+        let tick_duration = Duration::from_millis(max_duration.as_secs() * 1000 / (DEFAULT_TIMER_SLOTS as u64) + 1);
         let timer = tokio_timer::wheel()
             .tick_duration(tick_duration)
             .max_capacity(pow_maximum_timers + 1)


### PR DESCRIPTION
…e Timer Configuration From PeerManagerBuilder

Ref #87 

Running in to issues with `tokio_timer` when configuring the timer at the unwrap call on https://github.com/tokio-rs/tokio-timer/blob/master/src/worker.rs#L56, will investigate that a bit.