### PR TITLE
Use Router::uTorrent in DHT example

### DIFF
--- a/bip_dht/examples/debug.rs
+++ b/bip_dht/examples/debug.rs
@@ -75,8 +75,7 @@ fn main() {
     let hash = InfoHash::from_bytes(b"My Unique Info Hash");
     
     let handshaker = SimpleHandshaker{ filter: HashSet::new(), count: 0 };
-    let router = "46.101.197.175:443".to_socket_addrs().unwrap().next().unwrap();
-    let dht = DhtBuilder::with_router(Router::Custom(router)).set_source_addr(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 6889)))
+    let dht = DhtBuilder::with_router(Router::uTorrent).set_source_addr(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 6889)))
     .set_read_only(false).start_mainline(handshaker).unwrap();
     
     // Spawn a thread to listen to and report events


### PR DESCRIPTION
The example didn't work for me out of the box, but this change made it work. I think this change could help others to get started more easily with `bip-dht`.