### PR TITLE
Make Handshaker Take An Intance Of Transport Instead Of Just The Type

### DIFF
--- a/bip_handshake/examples/handshake_torrent.rs
+++ b/bip_handshake/examples/handshake_torrent.rs
@@ -35,7 +35,7 @@ fn main() {
     let peer_id = (*b"-UT2060-000000000000").into();
     let handshaker = HandshakerBuilder::new()
         .with_peer_id(peer_id)
-        .build::<TcpTransport>(core.handle())
+        .build(TcpTransport, core.handle())
         .unwrap()
         .send(InitiateMessage::new(Protocol::BitTorrent, hash, addr))
         .wait()

--- a/bip_handshake/src/transport.rs
+++ b/bip_handshake/src/transport.rs
@@ -22,10 +22,10 @@ pub trait Transport {
     type Listener: Stream<Item=(Self::Socket, SocketAddr), Error=io::Error> + LocalAddr + 'static;
 
     /// Connect to the given address over this transport, using the supplied `Handle`.
-    fn connect(addr: &SocketAddr, handle: &Handle) -> io::Result<Self::FutureSocket>;
+    fn connect(&self, addr: &SocketAddr, handle: &Handle) -> io::Result<Self::FutureSocket>;
 
     /// Listen to the given address for this transport, using the supplied `Handle`.
-    fn listen(addr: &SocketAddr, handle: &Handle) -> io::Result<Self::Listener>;
+    fn listen(&self, addr: &SocketAddr, handle: &Handle) -> io::Result<Self::Listener>;
 }
 
 //----------------------------------------------------------------------------------//
@@ -38,11 +38,11 @@ impl Transport for TcpTransport {
     type FutureSocket = TcpStreamNew;
     type Listener = TcpListenerStream<Incoming>;
 
-    fn connect(addr: &SocketAddr, handle: &Handle) -> io::Result<Self::FutureSocket> {
+    fn connect(&self, addr: &SocketAddr, handle: &Handle) -> io::Result<Self::FutureSocket> {
         Ok(TcpStream::connect(addr, handle))
     }
 
-    fn listen(addr: &SocketAddr, handle: &Handle) -> io::Result<Self::Listener> {
+    fn listen(&self, addr: &SocketAddr, handle: &Handle) -> io::Result<Self::Listener> {
         let listener = try!(TcpListener::bind(addr, handle));
         let listen_addr = try!(listener.local_addr());
 
@@ -99,11 +99,11 @@ pub mod test_transports {
         type FutureSocket = FutureResult<Self::Socket, io::Error>;
         type Listener     = MockListener;
 
-        fn connect(_addr: &SocketAddr, _handle: &Handle) -> io::Result<Self::FutureSocket> {
+        fn connect(&self, _addr: &SocketAddr, _handle: &Handle) -> io::Result<Self::FutureSocket> {
             Ok(future::ok(Cursor::new(Vec::new())))
         }
 
-        fn listen(addr: &SocketAddr, _handle: &Handle) -> io::Result<Self::Listener> {
+        fn listen(&self, addr: &SocketAddr, _handle: &Handle) -> io::Result<Self::Listener> {
             Ok(MockListener::new(*addr))
         }
     }

--- a/bip_handshake/test/test_byte_after_handshake.rs
+++ b/bip_handshake/test/test_byte_after_handshake.rs
@@ -21,7 +21,7 @@ fn positive_recover_bytes() {
     let handshaker_one = HandshakerBuilder::new()
         .with_bind_addr(handshaker_one_addr)
         .with_peer_id(handshaker_one_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_one_addr.set_port(handshaker_one.port());
 

--- a/bip_handshake/test/test_bytes_after_handshake.rs
+++ b/bip_handshake/test/test_bytes_after_handshake.rs
@@ -21,7 +21,7 @@ fn positive_recover_bytes() {
     let handshaker_one = HandshakerBuilder::new()
         .with_bind_addr(handshaker_one_addr)
         .with_peer_id(handshaker_one_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_one_addr.set_port(handshaker_one.port());
 

--- a/bip_handshake/test/test_connect.rs
+++ b/bip_handshake/test/test_connect.rs
@@ -17,7 +17,7 @@ fn positive_connect() {
     let handshaker_one = HandshakerBuilder::new()
         .with_bind_addr(handshaker_one_addr)
         .with_peer_id(handshaker_one_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_one_addr.set_port(handshaker_one.port());
 
@@ -27,7 +27,7 @@ fn positive_connect() {
     let handshaker_two = HandshakerBuilder::new()
         .with_bind_addr(handshaker_two_addr)
         .with_peer_id(handshaker_two_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_two_addr.set_port(handshaker_two.port());
 

--- a/bip_handshake/test/test_filter_allow_all.rs
+++ b/bip_handshake/test/test_filter_allow_all.rs
@@ -37,7 +37,7 @@ fn test_filter_all() {
     let handshaker_one = HandshakerBuilder::new()
         .with_bind_addr(handshaker_one_addr)
         .with_peer_id(handshaker_one_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_one_addr.set_port(handshaker_one.port());
     // Filter all incoming handshake requests
@@ -49,7 +49,7 @@ fn test_filter_all() {
     let handshaker_two = HandshakerBuilder::new()
         .with_bind_addr(handshaker_two_addr)
         .with_peer_id(handshaker_two_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_two_addr.set_port(handshaker_two.port());
 

--- a/bip_handshake/test/test_filter_block_all.rs
+++ b/bip_handshake/test/test_filter_block_all.rs
@@ -37,7 +37,7 @@ fn test_filter_all() {
     let handshaker_one = HandshakerBuilder::new()
         .with_bind_addr(handshaker_one_addr)
         .with_peer_id(handshaker_one_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_one_addr.set_port(handshaker_one.port());
     // Filter all incoming handshake requests
@@ -49,7 +49,7 @@ fn test_filter_all() {
     let handshaker_two = HandshakerBuilder::new()
         .with_bind_addr(handshaker_two_addr)
         .with_peer_id(handshaker_two_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_two_addr.set_port(handshaker_two.port());
 

--- a/bip_handshake/test/test_filter_whitelist_diff_data.rs
+++ b/bip_handshake/test/test_filter_whitelist_diff_data.rs
@@ -51,7 +51,7 @@ fn test_filter_whitelist_diff_data() {
     let handshaker_one = HandshakerBuilder::new()
         .with_bind_addr(handshaker_one_addr)
         .with_peer_id(handshaker_one_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_one_addr.set_port(handshaker_one.port());
     // Filter all incoming handshake requests hash's, then whitelist
@@ -66,7 +66,7 @@ fn test_filter_whitelist_diff_data() {
     let handshaker_two = HandshakerBuilder::new()
         .with_bind_addr(handshaker_two_addr)
         .with_peer_id(handshaker_two_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_two_addr.set_port(handshaker_two.port());
 

--- a/bip_handshake/test/test_filter_whitelist_same_data.rs
+++ b/bip_handshake/test/test_filter_whitelist_same_data.rs
@@ -51,7 +51,7 @@ fn test_filter_whitelist_same_data() {
     let handshaker_one = HandshakerBuilder::new()
         .with_bind_addr(handshaker_one_addr)
         .with_peer_id(handshaker_one_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_one_addr.set_port(handshaker_one.port());
     // Filter all incoming handshake requests hash's, then whitelist
@@ -66,7 +66,7 @@ fn test_filter_whitelist_same_data() {
     let handshaker_two = HandshakerBuilder::new()
         .with_bind_addr(handshaker_two_addr)
         .with_peer_id(handshaker_two_pid)
-        .build::<TcpTransport>(core.handle()).unwrap();
+        .build(TcpTransport, core.handle()).unwrap();
 
     handshaker_two_addr.set_port(handshaker_two.port());
 


### PR DESCRIPTION
Initial work required for user-land transport implementations such as utp.