### PR TITLE
Allow BytesMut To Store Cow Bytes For Fully Owned BencodeMut Objects

### DIFF
--- a/bip_bencode/Cargo.toml
+++ b/bip_bencode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name             = "bip_bencode"
-version          = "0.3.1"
+version          = "0.4.0"
 description      = "Efficient decoding and encoding for bencode"
 
 authors          = ["Andrew <amiller4421@gmail.com>"]

--- a/bip_bencode/src/access/convert.rs
+++ b/bip_bencode/src/access/convert.rs
@@ -1,7 +1,43 @@
+use access::bencode::BRefAccessExt;
 use access::bencode::BRefAccess;
 use error::{BencodeConvertErrorKind, BencodeConvertError};
 use access::dict::BDictAccess;
 use access::list::BListAccess;
+
+/// Trait for extended casting of bencode objects and converting conversion errors into application specific errors.
+pub trait BConvertExt: BConvert {
+    /// See BConvert::convert_bytes.
+    fn convert_bytes_ext<'a, B, E>(&self, bencode: B, error_key: E) -> Result<&'a [u8], Self::Error>
+        where B: BRefAccessExt<'a>, E: AsRef<[u8]>
+    {
+        bencode.bytes_ext().ok_or(self.handle_error(BencodeConvertError::from_kind(BencodeConvertErrorKind::WrongType{
+            key: error_key.as_ref().to_owned(), expected_type: "Bytes".to_owned()
+        })))
+    }
+
+    /// See BConvert::convert_str.
+    fn convert_str_ext<'a, B, E>(&self, bencode: &B, error_key: E) -> Result<&'a str, Self::Error>
+        where B: BRefAccessExt<'a>, E: AsRef<[u8]>
+    {
+        bencode.str_ext().ok_or(self.handle_error(BencodeConvertError::from_kind(BencodeConvertErrorKind::WrongType{
+            key: error_key.as_ref().to_owned(), expected_type: "UTF-8 Bytes".to_owned()
+        })))
+    }
+
+    /// See BConvert::lookup_and_convert_bytes.
+    fn lookup_and_convert_bytes_ext<'a, B, K1, K2>(&self, dictionary: &BDictAccess<K1, B>, key: K2) -> Result<&'a [u8], Self::Error>
+        where B: BRefAccessExt<'a>, K2: AsRef<[u8]>
+    {
+        self.convert_bytes_ext(try!(self.lookup(dictionary, &key)), &key)
+    }
+
+    /// See BConvert::lookup_and_convert_str.
+    fn lookup_and_convert_str_ext<'a, B, K1, K2>(&self, dictionary: &BDictAccess<K1, B>, key: K2) -> Result<&'a str, Self::Error>
+        where B: BRefAccessExt<'a>, K2: AsRef<[u8]>
+    {
+        self.convert_str_ext(try!(self.lookup(dictionary, &key)), &key)
+    }
+}
 
 /// Trait for casting bencode objects and converting conversion errors into application specific errors.
 pub trait BConvert {
@@ -13,8 +49,8 @@ pub trait BConvert {
     /// Attempt to convert the given bencode value into an integer.
     ///
     /// Error key is used to generate an appropriate error message should the operation return an error.
-    fn convert_int<'a, B, E>(&self, bencode: B, error_key: E) -> Result<i64, Self::Error>
-        where B: BRefAccess<'a>, E: AsRef<[u8]>
+    fn convert_int<B, E>(&self, bencode: B, error_key: E) -> Result<i64, Self::Error>
+        where B: BRefAccess, E: AsRef<[u8]>
     {
         bencode.int().ok_or(self.handle_error(BencodeConvertError::from_kind(BencodeConvertErrorKind::WrongType{
             key: error_key.as_ref().to_owned(), expected_type: "Integer".to_owned()
@@ -24,8 +60,8 @@ pub trait BConvert {
     /// Attempt to convert the given bencode value into bytes.
     ///
     /// Error key is used to generate an appropriate error message should the operation return an error.
-    fn convert_bytes<'a, B, E>(&self, bencode: B, error_key: E) -> Result<&'a [u8], Self::Error>
-        where B: BRefAccess<'a>, E: AsRef<[u8]>
+    fn convert_bytes<'a, B, E>(&self, bencode: &'a B, error_key: E) -> Result<&'a [u8], Self::Error>
+        where B: BRefAccess, E: AsRef<[u8]>
     {
         bencode.bytes().ok_or(self.handle_error(BencodeConvertError::from_kind(BencodeConvertErrorKind::WrongType{
             key: error_key.as_ref().to_owned(), expected_type: "Bytes".to_owned()
@@ -35,8 +71,8 @@ pub trait BConvert {
     /// Attempt to convert the given bencode value into a UTF-8 string.
     ///
     /// Error key is used to generate an appropriate error message should the operation return an error.
-    fn convert_str<'a, B, E>(&self, bencode: B, error_key: E) -> Result<&'a str, Self::Error>
-        where B: BRefAccess<'a>, E: AsRef<[u8]>
+    fn convert_str<'a, B, E>(&self, bencode: &'a B, error_key: E) -> Result<&'a str, Self::Error>
+        where B: BRefAccess, E: AsRef<[u8]>
     {
         bencode.str().ok_or(self.handle_error(BencodeConvertError::from_kind(BencodeConvertErrorKind::WrongType{
             key: error_key.as_ref().to_owned(), expected_type: "UTF-8 Bytes".to_owned()
@@ -46,8 +82,8 @@ pub trait BConvert {
     /// Attempty to convert the given bencode value into a list.
     ///
     /// Error key is used to generate an appropriate error message should the operation return an error.
-    fn convert_list<'a: 'b, 'b, B, E>(&self, bencode: &'b B, error_key: E) -> Result<&'b BListAccess<B::BType>, Self::Error>
-        where B: BRefAccess<'a>, E: AsRef<[u8]>
+    fn convert_list<'a, B, E>(&self, bencode: &'a B, error_key: E) -> Result<&'a BListAccess<B::BType>, Self::Error>
+        where B: BRefAccess, E: AsRef<[u8]>
     {
         bencode.list().ok_or(self.handle_error(BencodeConvertError::from_kind(BencodeConvertErrorKind::WrongType{
             key: error_key.as_ref().to_owned(), expected_type: "List".to_owned()
@@ -57,8 +93,8 @@ pub trait BConvert {
     /// Attempt to convert the given bencode value into a dictionary.
     ///
     /// Error key is used to generate an appropriate error message should the operation return an error.
-    fn convert_dict<'a, 'b, B, E>(&self, bencode: &'b B, error_key: E) -> Result<&'b BDictAccess<'a, B::BType>, Self::Error>
-        where B: BRefAccess<'a>, E: AsRef<[u8]>
+    fn convert_dict<'a, B, E>(&self, bencode: &'a B, error_key: E) -> Result<&'a BDictAccess<B::BKey, B::BType>, Self::Error>
+        where B: BRefAccess, E: AsRef<[u8]>
     {
         bencode.dict().ok_or(self.handle_error(BencodeConvertError::from_kind(BencodeConvertErrorKind::WrongType{
             key: error_key.as_ref().to_owned(), expected_type: "Dictionary".to_owned()
@@ -66,8 +102,8 @@ pub trait BConvert {
     }
 
     /// Look up a value in a dictionary of bencoded values using the given key.
-    fn lookup<'a, 'b, B, K>(&self, dictionary: &'b BDictAccess<'a, B>, key: K) -> Result<&'b B, Self::Error>
-        where B: BRefAccess<'a>, K: AsRef<[u8]>
+    fn lookup<'a, B, K1, K2>(&self, dictionary: &'a BDictAccess<K1, B>, key: K2) -> Result<&'a B, Self::Error>
+        where B: BRefAccess, K2: AsRef<[u8]>
     {
         let key_ref = key.as_ref();
 
@@ -78,36 +114,36 @@ pub trait BConvert {
     }
 
     /// Combines a lookup operation on the given key with a conversion of the value, if found, to an integer.
-    fn lookup_and_convert_int<'a, B, K>(&self, dictionary: &BDictAccess<'a, B>, key: K) -> Result<i64, Self::Error>
-        where B: BRefAccess<'a>, K: AsRef<[u8]>
+    fn lookup_and_convert_int<B, K1, K2>(&self, dictionary: &BDictAccess<K1, B>, key: K2) -> Result<i64, Self::Error>
+        where B: BRefAccess, K2: AsRef<[u8]>
     {
         self.convert_int(try!(self.lookup(dictionary, &key)), &key)
     }
 
     /// Combines a lookup operation on the given key with a conversion of the value, if found, to a series of bytes.
-    fn lookup_and_convert_bytes<'a, B, K>(&self, dictionary: &BDictAccess<'a, B>, key: K) -> Result<&'a [u8], Self::Error>
-        where B: BRefAccess<'a>, K: AsRef<[u8]>
+    fn lookup_and_convert_bytes<'a, B, K1, K2>(&self, dictionary: &'a BDictAccess<K1, B>, key: K2) -> Result<&'a [u8], Self::Error>
+        where B: BRefAccess, K2: AsRef<[u8]>
     {
         self.convert_bytes(try!(self.lookup(dictionary, &key)), &key)
     }
 
     /// Combines a lookup operation on the given key with a conversion of the value, if found, to a UTF-8 string.
-    fn lookup_and_convert_str<'a, B, K>(&self, dictionary: &BDictAccess<'a, B>, key: K) -> Result<&'a str, Self::Error>
-        where B: BRefAccess<'a>, K: AsRef<[u8]>
+    fn lookup_and_convert_str<'a, B, K1, K2>(&self, dictionary: &'a BDictAccess<K1, B>, key: K2) -> Result<&'a str, Self::Error>
+        where B: BRefAccess, K2: AsRef<[u8]>
     {
         self.convert_str(try!(self.lookup(dictionary, &key)), &key)
     }
 
     /// Combines a lookup operation on the given key with a conversion of the value, if found, to a list.
-    fn lookup_and_convert_list<'a, 'b, B, K>(&self, dictionary: &'b BDictAccess<'a, B>, key: K) -> Result<&'b BListAccess<B::BType>, Self::Error>
-        where B: BRefAccess<'a>, K: AsRef<[u8]>
+    fn lookup_and_convert_list<'a, B, K>(&self, dictionary: &'a BDictAccess<K, B>, key: K) -> Result<&'a BListAccess<B::BType>, Self::Error>
+        where B: BRefAccess, K: AsRef<[u8]>
     {
         self.convert_list(try!(self.lookup(dictionary, &key)), &key)
     }
 
     /// Combines a lookup operation on the given key with a conversion of the value, if found, to a dictionary.
-    fn lookup_and_convert_dict<'a, 'b, B, K>(&self, dictionary: &'b BDictAccess<'a, B>, key: K) -> Result<&'b BDictAccess<'a, B::BType>, Self::Error>
-        where B: BRefAccess<'a>, K: AsRef<[u8]>
+    fn lookup_and_convert_dict<'a, B, K1, K2>(&self, dictionary: &'a BDictAccess<K1, B>, key: K2) -> Result<&'a BDictAccess<B::BKey, B::BType>, Self::Error>
+        where B: BRefAccess, K2: AsRef<[u8]>
     {
         self.convert_dict(try!(self.lookup(dictionary, &key)), &key)
     }

--- a/bip_bencode/src/access/dict.rs
+++ b/bip_bencode/src/access/dict.rs
@@ -1,9 +1,10 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 /// Trait for working with generic map data structures.
-pub trait BDictAccess<'a, V> {
+pub trait BDictAccess<K, V> {
     /// Convert the dictionary to an unordered list of key/value pairs.
-    fn to_list(&self) -> Vec<(&'a [u8], &V)>;
+    fn to_list(&self) -> Vec<(&K, &V)>;
 
     /// Lookup a value in the dictionary.
     fn lookup(&self, key: &[u8]) -> Option<&V>;
@@ -12,15 +13,15 @@ pub trait BDictAccess<'a, V> {
     fn lookup_mut(&mut self, key: &[u8]) -> Option<&mut V>;
 
     /// Insert a key/value pair into the dictionary.
-    fn insert(&mut self, key: &'a [u8], value: V) -> Option<V>;
+    fn insert(&mut self, key: K, value: V) -> Option<V>;
 
     /// Remove a value from the dictionary and return it.
     fn remove(&mut self, key: &[u8]) -> Option<V>;
 }
 
-impl<'a, V> BDictAccess<'a, V> for BTreeMap<&'a [u8], V> {
-    fn to_list(&self) -> Vec<(&'a [u8], &V)> {
-        self.iter().map(|(k, v)| (*k, v)).collect()
+impl<'a, V> BDictAccess<&'a [u8], V> for BTreeMap<&'a [u8], V> {
+    fn to_list(&self) -> Vec<(&&'a [u8], &V)> {
+        self.iter().map(|(k, v)| (k, v)).collect()
     }
 
     fn lookup(&self, key: &[u8]) -> Option<&V> {
@@ -32,6 +33,28 @@ impl<'a, V> BDictAccess<'a, V> for BTreeMap<&'a [u8], V> {
     }
 
     fn insert(&mut self, key: &'a [u8], value: V) -> Option<V> {
+        self.insert(key, value)
+    }
+
+    fn remove(&mut self, key: &[u8]) -> Option<V> {
+        self.remove(key)
+    }
+}
+
+impl<'a, V> BDictAccess<Cow<'a, [u8]>, V> for BTreeMap<Cow<'a, [u8]>, V> {
+    fn to_list(&self) -> Vec<(&Cow<'a, [u8]>, &V)> {
+        self.iter().map(|(k, v)| (k, v)).collect()
+    }
+
+    fn lookup(&self, key: &[u8]) -> Option<&V> {
+        self.get(key)
+    }
+
+    fn lookup_mut(&mut self, key: &[u8]) -> Option<&mut V> {
+        self.get_mut(key)
+    }
+
+    fn insert(&mut self, key: Cow<'a, [u8]>, value: V) -> Option<V> {
         self.insert(key, value)
     }
 

--- a/bip_bencode/src/cow.rs
+++ b/bip_bencode/src/cow.rs
@@ -1,0 +1,44 @@
+use std::borrow::Cow;
+
+/// Trait for macros to convert owned/borrowed types to `Cow`.
+/// 
+/// This is needed because `&str` and `String` do not have `From`
+/// impls into `Cow<_, [u8]>`. One solution is to just call `AsRef<[u8]>`
+/// before converting. However, then when a user specifies an owned type,
+/// we will implicitly borrow that; this trait prevents that so that macro
+/// behavior is intuitive, so that owned types stay owned.
+pub trait BCowConvert<'a> {
+    fn convert(self) -> Cow<'a, [u8]>;
+}
+
+// TODO: Enable when specialization lands.
+/*
+impl<'a, T> BCowConvert<'a> for T where T: AsRef<[u8]> + 'a {
+    fn convert(self) -> Cow<'a, [u8]> {
+        self.into()
+    }
+}*/
+
+impl<'a> BCowConvert<'a> for &'a [u8] {
+    fn convert(self) -> Cow<'a, [u8]> {
+        self.into()
+    }
+}
+
+impl<'a> BCowConvert<'a> for &'a str {
+    fn convert(self) -> Cow<'a, [u8]> {
+        self.as_bytes().into()
+    }
+}
+
+impl BCowConvert<'static> for String {
+    fn convert(self) -> Cow<'static, [u8]> {
+        self.into_bytes().into()
+    }
+}
+
+impl BCowConvert<'static> for Vec<u8> {
+    fn convert(self) -> Cow<'static, [u8]> {
+        self.into()
+    }
+}

--- a/bip_bencode/src/lib.rs
+++ b/bip_bencode/src/lib.rs
@@ -27,10 +27,11 @@
 //!
 //!     fn main() {
 //!         let message = (ben_map!{
-//!             "lucky_number" => ben_int!(7)
+//!             "lucky_number" => ben_int!(7),
+//!             "lucky_string" => ben_bytes!("7")
 //!         }).encode();
 //!
-//!         assert_eq!(&b"d12:lucky_numberi7ee"[..], &message[..]);
+//!         assert_eq!(&b"d12:lucky_numberi7e12:lucky_string1:7e"[..], &message[..]);
 //!     }
 //! ```
 
@@ -38,14 +39,26 @@
 extern crate error_chain;
 
 mod access;
+mod cow;
 mod mutable;
 mod reference;
 mod error;
 
+/// Traits for implementation functionality.
+pub mod inner {
+    pub use cow::BCowConvert;
+}
+
+/// Traits for extended functionality.
+pub mod ext {
+    pub use access::convert::{BConvertExt};
+    pub use access::bencode::{BRefAccessExt};
+}
+
 pub use reference::bencode_ref::{BencodeRef};
 pub use mutable::bencode_mut::{BencodeMut};
 pub use access::bencode::{BRefAccess, BencodeRefKind, BMutAccess, BencodeMutKind};
-pub use access::convert::BConvert;
+pub use access::convert::{BConvert};
 pub use access::dict::BDictAccess;
 pub use access::list::BListAccess;
 pub use reference::decode_opt::BDecodeOpt;
@@ -66,14 +79,14 @@ const BYTE_LEN_END: u8 = b':';
 macro_rules! ben_map {
 ( $($key:expr => $val:expr),* ) => {
         {
-            use std::convert::{AsRef};
             use bip_bencode::{BMutAccess, BencodeMut};
+            use bip_bencode::inner::BCowConvert;
 
             let mut bencode_map = BencodeMut::new_dict();
             {
                 let mut map = bencode_map.dict_mut().unwrap();
                 $(
-                    map.insert(AsRef::as_ref($key), $val);
+                    map.insert(BCowConvert::convert($key), $val);
                 )*
             }
 
@@ -107,10 +120,10 @@ macro_rules! ben_list {
 macro_rules! ben_bytes {
     ( $ben:expr ) => {
         {
-            use std::convert::{AsRef};
             use bip_bencode::{BencodeMut};
+            use bip_bencode::inner::BCowConvert;
             
-            BencodeMut::new_bytes(AsRef::as_ref($ben))
+            BencodeMut::new_bytes(BCowConvert::convert($ben))
         }
     }
 }

--- a/bip_bencode/src/mutable/encode.rs
+++ b/bip_bencode/src/mutable/encode.rs
@@ -4,7 +4,8 @@ use access::list::BListAccess;
 
 use std::iter::Extend;
 
-pub fn encode<'a, T>(val: T, bytes: &mut Vec<u8>) where T: BRefAccess<'a> {
+pub fn encode<T>(val: T, bytes: &mut Vec<u8>)
+    where T: BRefAccess, T::BKey: AsRef<[u8]> {
     match val.kind() {
         BencodeRefKind::Int(n)  => encode_int(n, bytes),
         BencodeRefKind::Bytes(n) => encode_bytes(&n, bytes),
@@ -29,7 +30,8 @@ fn encode_bytes(list: &[u8], bytes: &mut Vec<u8>) {
     bytes.extend(list.iter().map(|n| *n));
 }
 
-fn encode_list<'a, T>(list: &BListAccess<T>, bytes: &mut Vec<u8>) where T: BRefAccess<'a> {
+fn encode_list<T>(list: &BListAccess<T>, bytes: &mut Vec<u8>)
+    where T: BRefAccess, T::BKey: AsRef<[u8]> {
     bytes.push(::LIST_START);
 
     for i in list {
@@ -39,15 +41,16 @@ fn encode_list<'a, T>(list: &BListAccess<T>, bytes: &mut Vec<u8>) where T: BRefA
     bytes.push(::BEN_END);
 }
 
-fn encode_dict<'a, T>(dict: &BDictAccess<'a, T>, bytes: &mut Vec<u8>) where T: BRefAccess<'a> {
+fn encode_dict<'a, K, V>(dict: &BDictAccess<K, V>, bytes: &mut Vec<u8>)
+    where K: AsRef<[u8]>, V: BRefAccess, V::BKey: AsRef<[u8]> {
     // Need To Sort The Keys In The Map Before Encoding
     let mut sort_dict = dict.to_list();
-    sort_dict.sort_by(|&(a, _), &(b, _)| a.cmp(b));
+    sort_dict.sort_by(|&(a, _), &(b, _)| a.as_ref().cmp(b.as_ref()));
 
     bytes.push(::DICT_START);
     // Iterate And Dictionary Encode The (String, Bencode) Pairs
     for &(ref key, ref value) in sort_dict.iter() {
-        encode_bytes(key, bytes);
+        encode_bytes(key.as_ref(), bytes);
         encode(*value, bytes);
     }
     bytes.push(::BEN_END);


### PR DESCRIPTION
Allows users to create owned `BencodeMut` objects which are useful for #122 and in `bip_select` where different modules want to add their own info required to function, to the `ExtendedMessage` object, even if we dont have specific setters for the fields required on the object itself.

This change makes it so that by default `BRefAccess` doesnt track the lifetime of the underlying buffer, since pulling a `&[u8]` from a `Cow`, erases any lifetime since the slice could be owned. Instead, we have `BRefAccessExt` that users can track if they started with a `BencodeRef`, so that they can still get slices that track the underlying buffer. Subsequently, we have the `BConvertExt`, for the corresponding conversions.