### PR TITLE
Unused mut warning when using ben_map and ben_list macro

### DIFF
--- a/bip_bencode/src/lib.rs
+++ b/bip_bencode/src/lib.rs
@@ -104,7 +104,7 @@ macro_rules! ben_list {
             
             let mut bencode_list = BencodeMut::new_list();
             {
-                let mut list = bencode_list.list_mut().unwrap();
+                let list = bencode_list.list_mut().unwrap();
                 $(
                     list.push($ben);
                 )*

--- a/bip_bencode/src/lib.rs
+++ b/bip_bencode/src/lib.rs
@@ -84,7 +84,7 @@ macro_rules! ben_map {
 
             let mut bencode_map = BencodeMut::new_dict();
             {
-                let mut map = bencode_map.dict_mut().unwrap();
+                let map = bencode_map.dict_mut().unwrap();
                 $(
                     map.insert(BCowConvert::convert($key), $val);
                 )*


### PR DESCRIPTION
I removed the unused `mut` for the macros `ben_map` and `ben_list`. Those were generating a warning from the compiler: `warning: variable does not need to be mutable`.

The related issue is https://github.com/GGist/bip-rs/issues/135.