### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/bip_metainfo/src/builder/worker.rs
+++ b/bip_metainfo/src/builder/worker.rs
@@ -349,7 +349,7 @@ mod tests {
         let region_lengths = [DEFAULT_PIECE_LENGTH * DEFAULT_NUM_PIECES,
                               DEFAULT_PIECE_LENGTH * 1,
                               DEFAULT_PIECE_LENGTH * 50];
-        for &region_length in region_lengths.into_iter() {
+        for &region_length in region_lengths.iter() {
             accessor.create_region(region_length);
         }
 
@@ -363,7 +363,7 @@ mod tests {
         let region_lengths = [DEFAULT_PIECE_LENGTH * DEFAULT_NUM_PIECES,
                               DEFAULT_PIECE_LENGTH * 1,
                               DEFAULT_PIECE_LENGTH * 50];
-        for &region_length in region_lengths.into_iter() {
+        for &region_length in region_lengths.iter() {
             accessor.create_region(region_length);
         }
 
@@ -378,7 +378,7 @@ mod tests {
                               DEFAULT_PIECE_LENGTH / 4 * DEFAULT_NUM_PIECES,
                               DEFAULT_PIECE_LENGTH * 1,
                               (DEFAULT_PIECE_LENGTH * 2 - 1) * 2];
-        for &region_length in region_lengths.into_iter() {
+        for &region_length in region_lengths.iter() {
             accessor.create_region(region_length);
         }
 
@@ -393,7 +393,7 @@ mod tests {
                               DEFAULT_PIECE_LENGTH / 4 * DEFAULT_NUM_PIECES,
                               DEFAULT_PIECE_LENGTH * 1,
                               (DEFAULT_PIECE_LENGTH * 2 - 1) * 2];
-        for &region_length in region_lengths.into_iter() {
+        for &region_length in region_lengths.iter() {
             accessor.create_region(region_length);
         }
 


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.